### PR TITLE
fix(ValidationMessage): Make spacing consistent with description component (#171)

### DIFF
--- a/src/components/PasswordInput/component.stories.tsx
+++ b/src/components/PasswordInput/component.stories.tsx
@@ -16,6 +16,7 @@ export const Text = () => {
       {...validationProps}
       value={value}
       onChange={(evt) => setValue(evt.target.value)}
+      description="Some description about the password."
     />
   );
 };

--- a/src/components/internal/ValidationMessage/index.tsx
+++ b/src/components/internal/ValidationMessage/index.tsx
@@ -26,7 +26,7 @@ export const ValidationMessageContainer = styled.ul`
 `;
 
 export const ValidationMessageItem = styled.li<Props>`
-  margin-top: ${({ theme }) => em(theme.honeycomb.size.small)};
+  margin-top: ${({ theme }) => em(4, theme.honeycomb.size.small)};
   display: flex;
   align-items: center;
   color: ${({ theme }) => theme.honeycomb.color.text.masked};


### PR DESCRIPTION
Particularly noticeable when you have both a description and validation (like in the browser extension, shown below).

<img src="https://user-images.githubusercontent.com/15721063/88159861-015db080-cc62-11ea-94f7-c2c387a89250.png" height=250 />