### PR TITLE
feat(ModalState): Allow a custom icon to be used in modal (#176)

### DIFF
--- a/src/components/ModalState/Icon/component.tsx
+++ b/src/components/ModalState/Icon/component.tsx
@@ -19,7 +19,7 @@ const icons: IconType = {
 };
 
 export const Component = ({ variant, children }: Props) => {
-  return <SvgContainer>{children ?? icons[variant]}</SvgContainer>;
+  return <SvgContainer variant={variant}>{children ?? icons[variant]}</SvgContainer>;
 };
 
 Component.displayName = 'ModalState.Icon';

--- a/src/components/ModalState/Icon/styled.tsx
+++ b/src/components/ModalState/Icon/styled.tsx
@@ -1,12 +1,31 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { em } from 'polished';
 
 import { Icon } from '../../Icon';
 
-export const SvgContainer = styled.div`
+export const variants = ['success', 'warning', 'danger'] as const;
+export type Variant = typeof variants[number];
+
+const success = css`
+  color: ${({ theme }) => theme.honeycomb.color.success.normal};
+`;
+
+const warning = css`
+  color: ${({ theme }) => theme.honeycomb.color.warning.normal};
+`;
+
+const danger = css`
+  color: ${({ theme }) => theme.honeycomb.color.danger.normal};
+`;
+
+export const SvgContainer = styled.div<{ variant?: Variant }>`
   font-size: ${em(64)};
   align-self: center;
   display: flex;
+
+  ${({ variant }) => variant === 'success' && success};
+  ${({ variant }) => variant === 'warning' && warning};
+  ${({ variant }) => variant === 'danger' && danger};
 `;
 
 export const Success = styled(Icon.Success)`

--- a/src/components/ModalState/component.stories.tsx
+++ b/src/components/ModalState/component.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Sections } from '../../modules/sections';
+import { Icon } from '../Icon';
 
 import { Variant } from './styled';
 
@@ -28,4 +29,15 @@ export const Default = () => (
   >
     {scenario.children}
   </ModalState>
+);
+
+export const WithCustomIcon = () => (
+  <ModalState
+    open={true}
+    data-testid="MyModal"
+    variant="success"
+    title={scenario.name}
+    description={scenario.description}
+    icon={<Icon.Tick />}
+  />
 );

--- a/src/components/ModalState/component.tsx
+++ b/src/components/ModalState/component.tsx
@@ -14,6 +14,7 @@ export type Props = React.ComponentPropsWithoutRef<typeof Modal> & {
 
 export const Component = ({
   variant,
+  icon,
   title,
   description,
   children,
@@ -24,7 +25,7 @@ export const Component = ({
 
   return (
     <StyledModal {...otherProps} data-testid={buildTestId()}>
-      <Icon variant={variant} />
+      <Icon variant={variant}>{icon}</Icon>
       <Title>{title}</Title>
       <Description>{description}</Description>
       {children}


### PR DESCRIPTION
Issue [#176](https://github.com/binance-chain/ui-project-management/issues/176).

<img height="200" src="https://user-images.githubusercontent.com/15721063/88891794-ddb8ec80-d297-11ea-853f-052d460911d7.png">

Allow a custom icon to be used. `variant` prop also now applies styles to custom icons.