### PR TITLE
fix(Modal): Error when closing the modal when it has children that change its state

### DIFF
--- a/src/components/Modal/component.tsx
+++ b/src/components/Modal/component.tsx
@@ -72,7 +72,7 @@ export const Component = ({
     return () => window.removeEventListener('click', listener);
   }, [open, onClose]);
 
-  if (!MODAL_CONTAINER) {
+  if (!MODAL_CONTAINER || !open) {
     return <>{null}</>;
   }
 


### PR DESCRIPTION
Fixes `Can't perform a React state update on an unmounted component. ...` error when the modal has children that can change its state (e.g. `Select` component that closes the modal on option selected).