### PR TITLE
fix: Button padding should match `TextInput` text indent

### DIFF
--- a/src/components/Button/styled.tsx
+++ b/src/components/Button/styled.tsx
@@ -150,7 +150,7 @@ export const Styled = styled.button<Props>`
   border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal, theme.honeycomb.size.reduced)};
   cursor: pointer;
   height: ${({ theme }) => em(theme.honeycomb.size.huge, theme.honeycomb.size.reduced)};
-  padding: 0 ${({ theme }) => em(theme.honeycomb.size.normal, theme.honeycomb.size.reduced)};
+  padding: 0 ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/components/TextInput/styled.tsx
+++ b/src/components/TextInput/styled.tsx
@@ -99,7 +99,7 @@ export const Left = styled.div`
   flex-direction: row;
   align-items: stretch;
   justify-content: stretch;
-  padding-left: ${({ theme }) => em(theme.honeycomb.size.increased)};
+  padding-left: ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
 `;
 
 export const Right = styled.div`
@@ -107,5 +107,5 @@ export const Right = styled.div`
   flex-direction: row;
   align-items: stretch;
   justify-content: stretch;
-  padding-right: ${({ theme }) => em(theme.honeycomb.size.increased)};
+  padding-right: ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
 `;


### PR DESCRIPTION
Before fix:
<img width="367" alt="Screenshot at Aug 07 16-31-05" src="https://user-images.githubusercontent.com/15721063/89613541-930e2480-d8d6-11ea-8a2c-10fe39c2a26b.png">
