### PR TITLE
fix: Remove click on outside to close as it does not allow nested modals

### DIFF
--- a/src/components/Modal/Header/component.tsx
+++ b/src/components/Modal/Header/component.tsx
@@ -9,10 +9,11 @@ import { TestIdContext } from '../context';
 
 import { Header, Title, LoadingState } from './styled';
 
-export type Props = Pick<React.ComponentPropsWithoutRef<typeof Modal>, 'onClose' | 'className'> &
+export type Props = Pick<React.ComponentPropsWithoutRef<typeof Modal>, 'className'> &
   Testable & {
     title?: React.ReactNode;
     isLoading?: boolean;
+    onClose?: () => void;
   };
 
 export const Component = ({

--- a/src/components/Modal/component.stories.tsx
+++ b/src/components/Modal/component.stories.tsx
@@ -17,7 +17,7 @@ export const Behaviour = () => {
       <Button variant="primary" onClick={() => setShow(true)} data-testid="OpenButton">
         Show
       </Button>
-      <Modal open={show} onClose={() => setShow(false)} data-testid="MyModal">
+      <Modal open={show} data-testid="MyModal">
         <Modal.Header onClose={() => setShow(false)} title="A title" />
         <Modal.Content>{items}</Modal.Content>
       </Modal>
@@ -66,3 +66,28 @@ export const WithoutTitle = () => (
     <Modal.Content>{items}</Modal.Content>
   </Modal>
 );
+
+export const WithInnerModal = () => {
+  const [show, setShow] = useState(false);
+  const [showInner, setShowInner] = useState(false);
+
+  return (
+    <>
+      <Button variant="primary" onClick={() => setShow(true)} data-testid="OpenButton">
+        Show Outer Modal
+      </Button>
+      <Modal open={show} data-testid="MyModal">
+        <Modal.Header onClose={() => setShow(false)} title="Outer Modal" />
+        <Modal.Content>
+          <Button variant="primary" onClick={() => setShowInner(true)} data-testid="OpenButton">
+            Show Inner Modal
+          </Button>
+          <Modal open={showInner} data-testid="MyModalInner">
+            <Modal.Header onClose={() => setShowInner(false)} title="Inner Modal" />
+            <Modal.Content>{items}</Modal.Content>
+          </Modal>
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+};

--- a/src/components/Modal/component.tsx
+++ b/src/components/Modal/component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { useTransition, animated } from 'react-spring';
 import ReactDOM from 'react-dom';
 
@@ -28,7 +28,6 @@ const MODAL_CONTAINER =
 
 export type Props = Testable & {
   open?: boolean;
-  onClose?: () => void;
   children?: React.ReactNode;
   className?: string;
   position?: Position;
@@ -36,7 +35,6 @@ export type Props = Testable & {
 
 export const Component = ({
   open = false,
-  onClose,
   children,
   'data-testid': testId,
   className,
@@ -56,21 +54,6 @@ export const Component = ({
     enter: { opacity: 1, transform: position === 'center' ? 'scale(1)' : 'translateY(0)' },
     leave: { opacity: 0, transform: position === 'center' ? 'scale(0.5)' : 'translateY(100vh)' },
   });
-
-  useEffect(() => {
-    if (!open) return;
-
-    const listener = (evt: MouseEvent) => {
-      const boxElement = boxRef.current;
-
-      if (!boxElement) return;
-      if (boxElement.contains(evt.target as Node)) return;
-      onClose?.();
-    };
-
-    window.addEventListener('click', listener);
-    return () => window.removeEventListener('click', listener);
-  }, [open, onClose]);
 
   if (!MODAL_CONTAINER || !open) {
     return <>{null}</>;

--- a/src/components/Select/variant/ModalSelect/component.tsx
+++ b/src/components/Select/variant/ModalSelect/component.tsx
@@ -9,6 +9,7 @@ import { StyledHeader } from './styled';
 export type Props = React.ComponentPropsWithoutRef<typeof Modal> & {
   title?: React.ReactNode;
   isLoading?: boolean;
+  onClose?: () => void;
 };
 
 export const Component = ({
@@ -24,7 +25,7 @@ export const Component = ({
 
   return (
     <SelectContext.Provider value={context}>
-      <Modal {...otherProps} onClose={onClose} data-testid={buildTestId()}>
+      <Modal {...otherProps} data-testid={buildTestId()}>
         <StyledHeader title={title} isLoading={isLoading} onClose={onClose} />
         <Modal.Content padding="none">{children}</Modal.Content>
       </Modal>


### PR DESCRIPTION
Nested modals do not work correctly. Closing a child modal also closes the parent due to the `onClickListener` that allows clicking outside of the modal to close to work correctly. Using a `Select` inside a `Modal` also does not work as the `Select` uses a `Modal` internally.

I have removed the "click outside to close" functionality for now to fix these issues.