### PR TITLE
fix(Table): Add key prop to pagination pages

### DIFF
--- a/src/components/Table/component.tsx
+++ b/src/components/Table/component.tsx
@@ -140,7 +140,7 @@ export const Component = <Data extends object>({
               {'<'}
             </Button>
             {filteredPageOptions.map((page, index) => (
-              <>
+              <React.Fragment key={page}>
                 <PageNumberButton
                   variant={page === pageIndex ? 'primary' : 'secondary'}
                   onClick={() => gotoPage(page)}
@@ -156,7 +156,7 @@ export const Component = <Data extends object>({
                       …
                     </PaginationEllipsis>
                   )}
-              </>
+              </React.Fragment>
             ))}
             <Button
               variant="secondary"


### PR DESCRIPTION
Fix `Each child in an array should have a unique "key" prop` warning.