### PR TITLE
fix: Don't include space if there is no display symbol (#276)

### DIFF
--- a/src/modules/intl/getCryptoAssetFormatter/index.tsx
+++ b/src/modules/intl/getCryptoAssetFormatter/index.tsx
@@ -13,7 +13,7 @@ export const getCryptoAssetFormatter = ({
   });
 
   const format: typeof formatter.format = (number) =>
-    `${formatter.format(number)}${NON_BREAKING_SPACE}${displaySymbol}`;
+    `${formatter.format(number)}${displaySymbol ? NON_BREAKING_SPACE : ''}${displaySymbol}`;
 
   const formatToParts: typeof formatter.formatToParts = (number) => [
     ...formatter.formatToParts(number),


### PR DESCRIPTION
Issue [#276](https://github.com/binance-chain/ui-project-management/issues/276).

Using `formatCryptoAsset` without a symbol should return a string that can be parsed as a number.

Example use:
<img width="373" alt="image" src="https://user-images.githubusercontent.com/15721063/90765156-90cbb180-e33d-11ea-96d8-8826b8fcbb9f.png">
If `max="50"`, we want to display "50.00" in the number input but "50.00 " is not a vaild number.