### PR TITLE
feat(SegmentedControl): Should take 100% of available width by default (#301)

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,1 +1,2 @@
 export { Component as Button } from './component';
+export { Size, Shape } from './styled';

--- a/src/components/SegmentedControl/component.stories.tsx
+++ b/src/components/SegmentedControl/component.stories.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 
 import { Sections } from '../../modules/sections';
+import { sizes } from '../Button/styled';
 import { Space } from '../Space';
-
-import { sizes } from './styled';
 
 import { SegmentedControl } from './';
 
@@ -33,6 +32,7 @@ export const Default = () => {
           </SegmentedControl>
         </div>
       ))}
+
       <h3>disabled</h3>
       <SegmentedControl onChange={alert} selectedIndex={0} disabled>
         <span>BTC</span>
@@ -51,6 +51,12 @@ export const Default = () => {
         <span>SWINGBY</span>
         <span>USDS</span>
         <span>TUSD</span>
+      </SegmentedControl>
+
+      <h3>fit</h3>
+      <SegmentedControl onChange={alert} selectedIndex={0} shape="fit">
+        <span>BTC</span>
+        <span>BNB</span>
       </SegmentedControl>
     </div>
   );

--- a/src/components/SegmentedControl/component.tsx
+++ b/src/components/SegmentedControl/component.tsx
@@ -1,14 +1,16 @@
 import React, { useCallback } from 'react';
 
 import { Testable, useBuildTestId } from '../../modules/test-ids';
+import { Size } from '../Button';
 
-import { Container, Element, Size, Scroll } from './styled';
+import { Container, Element, Scroll, Shape } from './styled';
 
 export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as' | 'size' | 'onChange'> &
   Testable & {
     children: React.ReactNodeArray;
     selectedIndex?: number;
     size?: Size;
+    shape?: Shape;
     onChange?: (params: { selectedIndex: number }) => void;
   };
 
@@ -19,6 +21,7 @@ export const Component = ({
   selectedIndex = 0,
   'data-testid': testId,
   size = 'huge',
+  shape = 'fill',
   ...otherProps
 }: Props) => {
   const buildTestId = useBuildTestId(testId);
@@ -33,7 +36,13 @@ export const Component = ({
 
   return (
     <Scroll>
-      <Container data-testid={buildTestId()} disabled={disabled} size={size} {...otherProps}>
+      <Container
+        data-testid={buildTestId()}
+        disabled={disabled}
+        size={size}
+        shape={shape}
+        {...otherProps}
+      >
         {children.map((option, index) => {
           const isSelected = children[selectedIndex] === option;
           return (

--- a/src/components/SegmentedControl/styled.tsx
+++ b/src/components/SegmentedControl/styled.tsx
@@ -1,14 +1,15 @@
 import styled, { css } from 'styled-components';
 import { em, transitions } from 'polished';
 
-import { styleless as stylelessCommon } from '../Styleless';
 import { boxSizing } from '../../modules/box-sizing';
+import { Size, Shape as ButtonShape } from '../Button';
+import { styleless } from '../Styleless';
 
-export const sizes = ['huge', 'increased'] as const;
-export type Size = typeof sizes[number];
+export type Shape = Omit<ButtonShape, 'square'>;
 
 export interface ContainerProps {
   size: Size;
+  shape: Shape;
   disabled?: boolean;
 }
 
@@ -16,24 +17,6 @@ export interface ElementProps {
   size: Size;
   active: boolean;
 }
-
-const elementHugeRadius = css`
-  border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal, theme.honeycomb.size.reduced)};
-`;
-
-const elementIncreasedRadius = css`
-  border-radius: ${({ theme }) => em(theme.honeycomb.radius.reduced, theme.honeycomb.size.reduced)};
-`;
-
-const containerIncreased = css`
-  height: ${({ theme }) => em(theme.honeycomb.size.increased)};
-  border-radius: ${({ theme }) => em(theme.honeycomb.radius.reduced)};
-`;
-
-const disabled = css`
-  opacity: 0.3;
-  pointer-events: none;
-`;
 
 const activeElement = css`
   cursor: auto;
@@ -49,27 +32,54 @@ export const Element = styled.li<ElementProps>`
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  width: 100%;
   height: 100%;
   padding: 0 ${({ theme }) => em(theme.honeycomb.size.normal, theme.honeycomb.size.reduced)};
   font-weight: 600;
   font-size: ${({ theme }) => em(theme.honeycomb.size.reduced)};
-  ${elementHugeRadius};
-  ${({ size }) => size === 'increased' && elementIncreasedRadius};
+
+  border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal, theme.honeycomb.size.reduced)};
+
+  ${({ size }) =>
+    size === 'increased' &&
+    css`
+      border-radius: ${({ theme }) =>
+        em(theme.honeycomb.radius.reduced, theme.honeycomb.size.reduced)};
+    `};
   ${({ theme }) => transitions(['background', 'color'], theme.honeycomb.duration.normal)};
   ${({ active }) => active && activeElement}
 `;
 
 export const Container = styled.ul<ContainerProps>`
-  ${stylelessCommon};
+  ${styleless};
   ${boxSizing};
+
+  display: flex;
+  width: 100%;
   height: ${({ theme }) => em(theme.honeycomb.size.huge)};
   position: relative;
   background: ${({ theme }) => theme.honeycomb.color.secondary.normal};
   color: ${({ theme }) =>
     theme.honeycomb.color.readable.normal(theme.honeycomb.color.secondary.normal)};
   border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
-  ${({ size }) => size === 'increased' && containerIncreased};
-  ${({ disabled: isDisabled }) => isDisabled && disabled};
+
+  ${({ size }) =>
+    size === 'increased' &&
+    css`
+      height: ${({ theme }) => em(theme.honeycomb.size.increased)};
+      border-radius: ${({ theme }) => em(theme.honeycomb.radius.reduced)};
+    `};
+  ${({ shape }) =>
+    shape === 'fit' &&
+    css`
+      width: auto;
+    `};
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      opacity: 0.3;
+      pointer-events: none;
+    `};
 `;
 
 export const Scroll = styled.div`


### PR DESCRIPTION
Issue [#301](https://github.com/binance-chain/ui-project-management/issues/301).

`size="fill"` by default. Button `Size` and `Shape` are exported so we can re-use them for consistency.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/15721063/91686154-a6986c80-ebb0-11ea-861b-0ca2cd87dd65.png">
