### PR TITLE
feat(Select): Add `target` prop and `Select.DefaultTarget` (#300)

### DIFF
--- a/cypress/integration/Select.ts
+++ b/cypress/integration/Select.ts
@@ -37,7 +37,7 @@ describe('Select', () => {
     cy.visitStory({ storyId: 'elements-select--behaviour', themeId: 'GoldLight' });
     cy.tick(10000);
 
-    cy.get('[data-testid="open-btn"]').click();
+    cy.get('[data-testid="select"]').click();
     cy.tick(10000);
 
     cy.get('[data-testid="select.modal.item.0"]').should('be.visible');
@@ -63,7 +63,7 @@ describe('Select', () => {
 
     cy.get('[data-testid="select.modal.box"]').should('not.exist');
 
-    cy.get('[data-testid="open-btn"]').click();
+    cy.get('[data-testid="select"]').click();
     cy.tick(10000);
 
     cy.get('[data-testid="select.modal.box"]').should('be.visible');

--- a/src/components/Dropdown/DefaultTarget/component.tsx
+++ b/src/components/Dropdown/DefaultTarget/component.tsx
@@ -2,9 +2,8 @@ import React, { useContext } from 'react';
 
 import { ShowingContext } from '../context';
 import { Icon } from '../../Icon';
+import { DefaultTarget } from '../../internal/DefaultTarget';
 import { Styleless } from '../../Styleless';
-
-import { Container } from './styled';
 
 export const Component = ({
   htmlTag = 'button',
@@ -12,11 +11,11 @@ export const Component = ({
 }: Partial<React.ComponentPropsWithoutRef<typeof Styleless>> & { children: React.ReactNode }) => {
   const isShowing = useContext(ShowingContext);
   return (
-    <Container {...otherProps} as={htmlTag as any} isShowing={isShowing}>
+    <DefaultTarget {...otherProps} as={htmlTag as any} isShowing={isShowing}>
       {otherProps.children}
       &nbsp;
       <Icon.TriangleDown />
-    </Container>
+    </DefaultTarget>
   );
 };
 

--- a/src/components/ListItem/styled.tsx
+++ b/src/components/ListItem/styled.tsx
@@ -24,11 +24,6 @@ export const Styled = styled.button<{ isInteractive: boolean; showBorder: boolea
   width: 100%;
   ${({ theme }) => transitions(['background', 'color', 'border'], theme.honeycomb.duration.normal)};
 
-  :focus,
-  :focus-within {
-    box-shadow: 0 0 5px 1px ${({ theme }) => theme.honeycomb.color.primary.normal};
-  }
-
   :hover,
   :active {
     text-decoration: none;
@@ -70,9 +65,11 @@ export const Content = styled.div`
 `;
 
 export const Left = styled.div`
+  display: flex;
   margin-right: ${({ theme }) => em(theme.honeycomb.size.small)};
 `;
 
 export const Right = styled.div`
+  display: flex;
   margin-left: ${({ theme }) => em(theme.honeycomb.size.small)};
 `;

--- a/src/components/Select/DefaultTarget/component.tsx
+++ b/src/components/Select/DefaultTarget/component.tsx
@@ -19,7 +19,7 @@ export const Component = ({
 
   return (
     <DefaultTarget onClick={onClick} data-testid={buildTestId()}>
-      <StyledListItem {...otherProps} showBorder={false} isInteractive={false} showCaretRight>
+      <StyledListItem showCaretRight showBorder={false} isInteractive={false} {...otherProps}>
         {children}
       </StyledListItem>
     </DefaultTarget>

--- a/src/components/Select/DefaultTarget/component.tsx
+++ b/src/components/Select/DefaultTarget/component.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { Testable, useBuildTestId } from '../../../modules/test-ids';
+import { ListItem } from '../../ListItem';
+import { Button } from '../../Button';
+
+import { StyledButton, StyledListItem } from './styled';
+
+export type Props = Pick<React.ComponentPropsWithoutRef<typeof Button>, 'shape'> &
+  React.ComponentPropsWithoutRef<typeof ListItem> &
+  Testable;
+
+export const Component = ({
+  children,
+  shape,
+  'data-testid': testId,
+  onClick,
+  ...otherProps
+}: Props) => {
+  const buildTestId = useBuildTestId(testId);
+
+  return (
+    <StyledButton variant="secondary" shape={shape} onClick={onClick}>
+      <StyledListItem
+        {...otherProps}
+        showBorder={false}
+        isInteractive={false}
+        showCaretRight
+        data-testid={buildTestId()}
+      >
+        {children}
+      </StyledListItem>
+    </StyledButton>
+  );
+};
+
+Component.displayName = 'Select.DefaultTarget';

--- a/src/components/Select/DefaultTarget/component.tsx
+++ b/src/components/Select/DefaultTarget/component.tsx
@@ -1,36 +1,28 @@
 import React from 'react';
 
 import { Testable, useBuildTestId } from '../../../modules/test-ids';
+import { DefaultTarget } from '../../internal/DefaultTarget';
 import { ListItem } from '../../ListItem';
-import { Button } from '../../Button';
 
-import { StyledButton, StyledListItem } from './styled';
+import { StyledListItem } from './styled';
 
-export type Props = Pick<React.ComponentPropsWithoutRef<typeof Button>, 'shape'> &
-  React.ComponentPropsWithoutRef<typeof ListItem> &
-  Testable;
+export type Props = React.ComponentPropsWithoutRef<typeof ListItem> & Testable;
 
 export const Component = ({
   children,
   shape,
-  'data-testid': testId,
   onClick,
+  'data-testid': testId,
   ...otherProps
 }: Props) => {
   const buildTestId = useBuildTestId(testId);
 
   return (
-    <StyledButton variant="secondary" shape={shape} onClick={onClick}>
-      <StyledListItem
-        {...otherProps}
-        showBorder={false}
-        isInteractive={false}
-        showCaretRight
-        data-testid={buildTestId()}
-      >
+    <DefaultTarget onClick={onClick} data-testid={buildTestId()}>
+      <StyledListItem {...otherProps} showBorder={false} isInteractive={false} showCaretRight>
         {children}
       </StyledListItem>
-    </StyledButton>
+    </DefaultTarget>
   );
 };
 

--- a/src/components/Select/DefaultTarget/index.tsx
+++ b/src/components/Select/DefaultTarget/index.tsx
@@ -1,0 +1,1 @@
+export { Component as DefaultTarget } from './component';

--- a/src/components/Select/DefaultTarget/styled.tsx
+++ b/src/components/Select/DefaultTarget/styled.tsx
@@ -1,12 +1,6 @@
 import styled from 'styled-components';
 
-import { Button } from '../../Button';
 import { ListItem } from '../../ListItem';
-
-export const StyledButton = styled(Button)`
-  padding: 0;
-  font-weight: 400;
-`;
 
 export const StyledListItem = styled(ListItem)`
   height: auto;

--- a/src/components/Select/DefaultTarget/styled.tsx
+++ b/src/components/Select/DefaultTarget/styled.tsx
@@ -3,5 +3,5 @@ import styled from 'styled-components';
 import { ListItem } from '../../ListItem';
 
 export const StyledListItem = styled(ListItem)`
-  height: auto;
+  height: 100%;
 `;

--- a/src/components/Select/DefaultTarget/styled.tsx
+++ b/src/components/Select/DefaultTarget/styled.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+import { Button } from '../../Button';
+import { ListItem } from '../../ListItem';
+
+export const StyledButton = styled(Button)`
+  padding: 0;
+  font-weight: 400;
+`;
+
+export const StyledListItem = styled(ListItem)`
+  height: auto;
+`;

--- a/src/components/Select/component.stories.tsx
+++ b/src/components/Select/component.stories.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { Sections } from '../../modules/sections';
-import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { ListItem } from '../ListItem';
 
@@ -72,28 +71,23 @@ export const Default = () => {
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState<Option>();
 
-  const renderSelected = () => {
-    if (!selected) return 'Select an option...';
-
-    return (
-      <>
-        <span style={{ marginRight: '1em' }}>You have selected:</span>
-        {selected.label}
-      </>
-    );
-  };
-
   return (
     <>
-      <Button variant="transparent" onClick={() => setOpen((value) => !value)} data-testid="select">
-        {renderSelected()}
-      </Button>
       <Select
         data-testid="select"
         title="A Title"
         optionsTitle="Options"
         open={open}
         onClose={() => setOpen(false)}
+        target={
+          <Select.DefaultTarget
+            onClick={() => setOpen((value) => !value)}
+            left={selected ? <selected.icon /> : undefined}
+            data-testid="select"
+          >
+            {selected ? selected.label : 'Select an option...'}
+          </Select.DefaultTarget>
+        }
       >
         {data.map((it, index) => (
           <Select.Option
@@ -124,10 +118,17 @@ export const Behaviour = () => {
 
   return (
     <>
-      <Button variant="primary" onClick={() => setOpen(true)} data-testid="open-btn">
-        Show
-      </Button>
-      <Select data-testid="select" title="A Title" open={open} onClose={() => setOpen(false)}>
+      <Select
+        data-testid="select"
+        title="A Title"
+        open={open}
+        onClose={() => setOpen(false)}
+        target={
+          <Select.DefaultTarget onClick={() => setOpen((value) => !value)} data-testid="select">
+            {selected ? selected : 'Select an option...'}
+          </Select.DefaultTarget>
+        }
+      >
         <StyledSelectOption
           searchAs={['my photo', 'A crazy item']}
           isSelected={selected === 'photo'}

--- a/src/components/Select/component.tsx
+++ b/src/components/Select/component.tsx
@@ -13,13 +13,14 @@ export type Props = Pick<React.HTMLProps<HTMLElement>, 'children'> &
     title?: React.ReactNode;
     optionsTitle?: React.ReactNode;
     open: boolean;
+    target: React.ReactNode;
     onClose?: () => void;
   };
 
 export const Component = ({
-  'data-testid': testId,
   children,
   optionsTitle,
+  'data-testid': testId,
   ...otherProps
 }: Props) => {
   const buildTestId = useBuildTestId(testId);

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,8 +1,11 @@
 import { Component } from './component';
+import { DefaultTarget } from './DefaultTarget';
 import { Option } from './Option';
 
 export const Select = Component as typeof Component & {
+  DefaultTarget: typeof DefaultTarget;
   Option: typeof Option;
 };
 
+Select.DefaultTarget = DefaultTarget;
 Select.Option = Option;

--- a/src/components/Select/variant/DropdownSelect/component.tsx
+++ b/src/components/Select/variant/DropdownSelect/component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 
 import { useBuildTestId } from '../../../../modules/test-ids';
 import { useWindowSize, sizes } from '../../../internal/useWindowSize';
@@ -11,14 +11,16 @@ import { StyledContent } from './styled';
 
 export type Props = Omit<React.ComponentProps<typeof Select>, 'variant'>;
 
-export const Component = ({ 'data-testid': testId, onClose, ...otherProps }: Props) => {
+export const Component = ({ target, onClose, 'data-testid': testId, ...otherProps }: Props) => {
   const context = useMemo(() => ({ onClose, testId }), [onClose, testId]);
   const buildTestId = useBuildTestId(testId);
+  const targetRef = useRef<HTMLDivElement>(null);
 
   const { width, height } = useWindowSize();
 
   return (
     <>
+      <div ref={targetRef}>{target}</div>
       {width < sizes.sm || height < sizes.sm ? (
         <ModalSelect
           open={otherProps.open}
@@ -35,8 +37,8 @@ export const Component = ({ 'data-testid': testId, onClose, ...otherProps }: Pro
             interactive={true}
             arrow={false}
             content={<StyledContent>{otherProps.children}</StyledContent>}
-            onClickContent={() => onClose?.()}
             visible={otherProps.open}
+            reference={targetRef}
             data-testid={buildTestId('dropdown')}
           />
         </SelectContext.Provider>

--- a/src/components/Tooltip/component.tsx
+++ b/src/components/Tooltip/component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import Tippy from '@tippyjs/react';
 
 import { useBuildTestId, Testable } from '../../modules/test-ids';
@@ -25,7 +25,6 @@ export type Props = Pick<React.HTMLProps<HTMLElement>, 'children'> &
     content: React.ReactNode;
     trigger: TriggerValue | TriggerValue[];
     target: React.ReactNode;
-    onClickContent?: () => void;
   };
 
 export const Component = ({ 'data-testid': testId, ...otherProps }: Props) => {
@@ -34,23 +33,6 @@ export const Component = ({ 'data-testid': testId, ...otherProps }: Props) => {
     if (!Array.isArray(otherProps.trigger)) return otherProps.trigger;
     return otherProps.trigger.join(' ');
   }, [otherProps.trigger]);
-  const tooltipContentRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!otherProps.onClickContent || !otherProps.visible) return;
-
-    const listener = (evt: MouseEvent) => {
-      const tooltipContent = tooltipContentRef.current;
-
-      if (!tooltipContent) return;
-      if (tooltipContent.contains(evt.target as Node)) return;
-
-      otherProps.onClickContent?.();
-    };
-
-    window.addEventListener('click', listener);
-    return () => window.removeEventListener('click', listener);
-  }, [otherProps.onClickContent, otherProps.visible]);
 
   return (
     <>
@@ -64,7 +46,7 @@ export const Component = ({ 'data-testid': testId, ...otherProps }: Props) => {
         animation="shift-away"
         placement={otherProps.placement ?? 'bottom-start'}
         content={
-          <ContentContainer data-testid={buildTestId('content')} ref={tooltipContentRef}>
+          <ContentContainer data-testid={buildTestId('content')}>
             {otherProps.content}
           </ContentContainer>
         }

--- a/src/components/internal/DefaultTarget/index.tsx
+++ b/src/components/internal/DefaultTarget/index.tsx
@@ -4,25 +4,15 @@ import { transitions, em } from 'polished';
 import { styleless } from '../../Styleless';
 import { boxSizing } from '../../../modules/box-sizing';
 
-export const Container = styled.div<{ isShowing: boolean }>`
+export const DefaultTarget = styled.div`
   ${styleless};
   ${boxSizing};
 
   width: 100%;
-  background: ${({ theme }) => theme.honeycomb.color.bg.masked};
+  background: ${({ theme }) => theme.honeycomb.color.bg.input.normal};
   border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal, theme.honeycomb.size.reduced)};
-  color: ${({ theme }) => theme.honeycomb.color.readable.normal(theme.honeycomb.color.bg.normal)};
   height: ${({ theme }) => em(theme.honeycomb.size.huge, theme.honeycomb.size.reduced)};
-  padding: 0 ${({ theme }) => em(theme.honeycomb.size.increased, theme.honeycomb.size.reduced)};
   font-size: ${({ theme }) => em(theme.honeycomb.size.reduced)};
   cursor: pointer;
   ${({ theme }) => transitions(['background', 'color'], theme.honeycomb.duration.normal)};
-
-  :focus,
-  :hover,
-  :active {
-    background: ${({ theme }) => theme.honeycomb.color.bg.tooltip.accent};
-    color: ${({ theme }) =>
-      theme.honeycomb.color.readable.normal(theme.honeycomb.color.bg.tooltip.accent)};
-  }
 `;


### PR DESCRIPTION
Issue [#300](https://github.com/binance-chain/ui-project-management/issues/300).

`Select.DefaultTarget` is a `ListItem`, so can have the same props (`left`, `right`, `showCaretRight` etc.).

<img width="350" alt="image" src="https://user-images.githubusercontent.com/15721063/92077607-df368100-ee10-11ea-8662-6513285cd679.png">
