### PR TITLE
feat(Button): Make `type="button"` by default

### DIFF
--- a/src/components/Button/component.tsx
+++ b/src/components/Button/component.tsx
@@ -26,6 +26,7 @@ export const Component = ({
   variant,
   size = 'huge',
   shape = 'fill',
+  type = 'button',
   ...otherProps
 }: Props) => {
   const buildTestId = useBuildTestId(testId);
@@ -60,6 +61,7 @@ export const Component = ({
       variant={variant}
       size={size}
       shape={shape}
+      type={type}
       onClick={click}
     >
       {children}


### PR DESCRIPTION
Issue [#288](https://github.com/binance-chain/ui-project-management/issues/288).

We use non-submit buttons within forms in the browser extension. Without the `type="button"` prop, the first button in the form is treated as the submit button, causing unexpected behaviour. Set `type="button"` by default so the button with prop `type="submit"` is treated as the submit component.