### PR TITLE
feat: Remove `is` from prop names for consistency

### DIFF
--- a/src/components/Dropdown/component.stories.tsx
+++ b/src/components/Dropdown/component.stories.tsx
@@ -27,13 +27,13 @@ export const WithHelpers = () => {
       <Dropdown.Divider />
       <Dropdown.Item variant="accent">Item 3</Dropdown.Item>
       <Dropdown.Divider />
-      <Dropdown.Item isSelected>Selected item</Dropdown.Item>
+      <Dropdown.Item selected>Selected item</Dropdown.Item>
       <Dropdown.Item disabled>Disabled item</Dropdown.Item>
       <Dropdown.Item variant="accent" disabled>
         Disabled accent item
       </Dropdown.Item>
       <Dropdown.Divider />
-      <Dropdown.Item isInteractive={false}>Non-interactive item</Dropdown.Item>
+      <Dropdown.Item interactive={false}>Non-interactive item</Dropdown.Item>
     </Dropdown>
   );
 };

--- a/src/components/Header/HeaderDrawer/component.tsx
+++ b/src/components/Header/HeaderDrawer/component.tsx
@@ -54,13 +54,13 @@ export const Component = ({
 
   const panels: Panels = useMemo(() => {
     return items.map((it, index) => {
-      const { children, target, isStyled, onClick, ...otherItemProps } = it;
+      const { children, target, styled, onClick, ...otherItemProps } = it;
 
       const targetKey = `panel-${index}`;
       const hasChildren = !!children && children.length > 0;
 
       return {
-        target: isStyled ? (
+        target: styled ? (
           <PanelElementItem key={targetKey}>
             <div onClick={(evt) => clickPanelItem(evt)}>{target}</div>
           </PanelElementItem>

--- a/src/components/Header/HeaderItems/component.tsx
+++ b/src/components/Header/HeaderItems/component.tsx
@@ -18,7 +18,7 @@ export const Component = ({ items, 'data-testid': testId, ...otherProps }: Props
   return (
     <Styled {...otherProps} data-testid={buildTestId()}>
       {items.map((it, index) => {
-        const { children, target, isStyled, ...otherItemProps } = it;
+        const { children, target, styled, ...otherItemProps } = it;
 
         if (children) {
           return (
@@ -33,7 +33,7 @@ export const Component = ({ items, 'data-testid': testId, ...otherProps }: Props
 
                 if (label) {
                   component.push(
-                    <Label key={`${index}-label-${indexChild}`} isInteractive={false}>
+                    <Label key={`${index}-label-${indexChild}`} interactive={false}>
                       {label}
                     </Label>,
                   );
@@ -55,7 +55,7 @@ export const Component = ({ items, 'data-testid': testId, ...otherProps }: Props
           );
         }
 
-        if (isStyled) {
+        if (styled) {
           return <React.Fragment key={index}>{target}</React.Fragment>;
         }
 

--- a/src/components/Header/component.stories.tsx
+++ b/src/components/Header/component.stories.tsx
@@ -41,7 +41,7 @@ const dropdown = [
 const nonCollapsible = [
   {
     target: <DefaultTarget style={{ padding: '0 1em' }}>Non-Collapsible Item</DefaultTarget>,
-    isStyled: true,
+    styled: true,
   },
 ];
 
@@ -138,7 +138,7 @@ export const WithComplexItems = () => (
           </Button>
         ),
         htmlTag: 'button',
-        isStyled: true,
+        styled: true,
       },
       {
         target: 'Dropdown Item',

--- a/src/components/Header/component.tsx
+++ b/src/components/Header/component.tsx
@@ -29,7 +29,7 @@ export type HeaderItem = Omit<
 > & {
   target: React.ReactNode;
   children?: HeaderChildItem[];
-  isStyled?: boolean;
+  styled?: boolean;
 };
 
 export type HeaderChildItem = Omit<HeaderItem, 'children' | 'type'> & {

--- a/src/components/ListItem/component.stories.tsx
+++ b/src/components/ListItem/component.stories.tsx
@@ -28,7 +28,7 @@ export const Default = () => (
     <StyledListItem right="a value" showCaretRight disabled>
       Disabled
     </StyledListItem>
-    <ListItem isSelected>Selected</ListItem>
+    <ListItem selected>Selected</ListItem>
     <ListItem
       left={
         <Button variant="secondary" size="increased" shape="fit">
@@ -59,7 +59,7 @@ export const Default = () => (
     >
       0x77f2f5db2f2195b5461a0a7504b3acbac7ff9bad
     </ListItem>
-    <ListItem isInteractive={false} htmlTag="div">
+    <ListItem interactive={false} htmlTag="div">
       Non-interactive
     </ListItem>
     <ListItem showBorder={false}>No border</ListItem>

--- a/src/components/ListItem/component.tsx
+++ b/src/components/ListItem/component.tsx
@@ -9,8 +9,8 @@ import { Styled, ContentContainer, Content, Left, Right } from './styled';
 
 export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as'> &
   Testable & {
-    isSelected?: boolean;
-    isInteractive?: boolean;
+    selected?: boolean;
+    interactive?: boolean;
     showBorder?: boolean;
     showCaretRight?: boolean;
     left?: React.ReactNode;
@@ -20,8 +20,8 @@ export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as'> &
 
 export const Component = ({
   htmlTag,
-  isSelected = false,
-  isInteractive = true,
+  selected = false,
+  interactive = true,
   showBorder = true,
   showCaretRight = false,
   children,
@@ -39,7 +39,7 @@ export const Component = ({
       {...otherProps}
       as={htmlTag as any}
       disabled={disabled}
-      isInteractive={isInteractive}
+      interactive={interactive}
       showBorder={showBorder}
       data-testid={buildTestId()}
     >
@@ -48,7 +48,7 @@ export const Component = ({
         <Content>{children}</Content>
       </ContentContainer>
       {right && <Right data-testid={buildTestId('right')}>{right}</Right>}
-      {isSelected && (
+      {selected && (
         <Right>
           <Icon.Tick
             fontSize={theme.honeycomb.size.reduced}

--- a/src/components/ListItem/styled.tsx
+++ b/src/components/ListItem/styled.tsx
@@ -10,7 +10,7 @@ const disabled = css`
   pointer-events: none;
 `;
 
-export const Styled = styled.button<{ isInteractive: boolean; showBorder: boolean }>`
+export const Styled = styled.button<{ interactive: boolean; showBorder: boolean }>`
   ${styleless};
   ${boxSizing};
 
@@ -34,8 +34,8 @@ export const Styled = styled.button<{ isInteractive: boolean; showBorder: boolea
   }
 
   ${({ disabled: isDisabled }) => isDisabled && disabled};
-  ${({ isInteractive }) =>
-    isInteractive &&
+  ${({ interactive }) =>
+    interactive &&
     css`
       cursor: pointer;
       ${hoverEffect};

--- a/src/components/Modal/Header/component.tsx
+++ b/src/components/Modal/Header/component.tsx
@@ -12,17 +12,11 @@ import { Header, Title, LoadingState } from './styled';
 export type Props = Pick<React.ComponentPropsWithoutRef<typeof Modal>, 'className'> &
   Testable & {
     title?: React.ReactNode;
-    isLoading?: boolean;
+    loading?: boolean;
     onClose?: () => void;
   };
 
-export const Component = ({
-  title,
-  isLoading,
-  className,
-  onClose,
-  'data-testid': testId,
-}: Props) => {
+export const Component = ({ title, loading, className, onClose, 'data-testid': testId }: Props) => {
   const parentTestId = useContext(TestIdContext);
   const buildTestId = useBuildTestId(
     testId ?? (parentTestId ? `${parentTestId}.header` : undefined),
@@ -31,7 +25,7 @@ export const Component = ({
   return (
     <Header hasHeader={!!title} className={className}>
       <Title>
-        {!!title && isLoading && (
+        {!!title && loading && (
           <LoadingState>
             <Loading />
           </LoadingState>

--- a/src/components/Modal/component.stories.tsx
+++ b/src/components/Modal/component.stories.tsx
@@ -32,9 +32,9 @@ export const WithTitle = () => (
   </Modal>
 );
 
-export const TitleComponetWithLoading = () => (
+export const TitleComponentWithLoading = () => (
   <Modal open={true} data-testid="MyModal">
-    <Modal.Header isLoading={true} title={<div>A title</div>} />
+    <Modal.Header loading={true} title={<div>A title</div>} />
     <Modal.Content>{items}</Modal.Content>
   </Modal>
 );

--- a/src/components/SegmentedControl/component.tsx
+++ b/src/components/SegmentedControl/component.tsx
@@ -48,14 +48,14 @@ export const Component = ({
         {...otherProps}
       >
         {children.map((option, index) => {
-          const isSelected = children[selectedIndex] === option;
+          const selected = children[selectedIndex] === option;
           return (
             <Element
-              active={isSelected}
+              active={selected}
               key={index}
               onClick={handleClickForOption({ selectedIndex: index })}
               data-testid={buildTestId(`${index}`)}
-              data-testisselected={isSelected}
+              data-testisselected={selected}
               size={size}
               variant={variant}
             >

--- a/src/components/Select/DefaultTarget/component.tsx
+++ b/src/components/Select/DefaultTarget/component.tsx
@@ -19,7 +19,7 @@ export const Component = ({
 
   return (
     <DefaultTarget onClick={onClick} data-testid={buildTestId()}>
-      <StyledListItem showCaretRight showBorder={false} isInteractive={false} {...otherProps}>
+      <StyledListItem showCaretRight showBorder={false} interactive={false} {...otherProps}>
         {children}
       </StyledListItem>
     </DefaultTarget>

--- a/src/components/Select/component.stories.tsx
+++ b/src/components/Select/component.stories.tsx
@@ -94,7 +94,7 @@ export const Responsive = () => {
             key={index}
             onClick={() => setSelected(it)}
             searchAs={it.label}
-            isSelected={selected?.label === it.label}
+            selected={selected?.label === it.label}
             data-testid={`${index}`}
             left={<it.icon />}
           >
@@ -134,7 +134,7 @@ export const Dropdown = () => {
             key={index}
             onClick={() => setSelected(it)}
             searchAs={it.label}
-            isSelected={selected?.label === it.label}
+            selected={selected?.label === it.label}
             data-testid={`${index}`}
             left={<it.icon />}
           >
@@ -172,7 +172,7 @@ export const Modal = () => {
       >
         <StyledSelectOption
           searchAs={['my photo', 'A crazy item']}
-          isSelected={selected === 'photo'}
+          selected={selected === 'photo'}
           onClick={() => setSelected('photo')}
           data-testid="photo"
           htmlTag="div"
@@ -183,7 +183,7 @@ export const Modal = () => {
           <Select.Option
             key={index}
             searchAs={it.label}
-            isSelected={selected === it.label}
+            selected={selected === it.label}
             onClick={() => setSelected(it.label)}
             data-testid={`${index}`}
             left={<it.icon />}

--- a/src/components/Select/variant/ModalSelect/component.tsx
+++ b/src/components/Select/variant/ModalSelect/component.tsx
@@ -9,13 +9,13 @@ import { StyledHeader } from './styled';
 
 export type Props = React.ComponentPropsWithoutRef<typeof Modal> &
   Omit<React.ComponentProps<typeof Select>, 'variant'> & {
-    isLoading?: boolean;
+    loading?: boolean;
   };
 
 export const Component = ({
   title,
   children,
-  isLoading,
+  loading,
   target,
   onClose,
   'data-testid': testId,
@@ -29,7 +29,7 @@ export const Component = ({
       {target}
       <SelectContext.Provider value={context}>
         <Modal {...otherProps} data-testid={buildTestId()}>
-          <StyledHeader title={title} isLoading={isLoading} onClose={onClose} />
+          <StyledHeader title={title} loading={loading} onClose={onClose} />
           <Modal.Content padding="none">{children}</Modal.Content>
         </Modal>
       </SelectContext.Provider>


### PR DESCRIPTION
Right now we use a mix of `isLoading` vs `loading`, `isInteractive` vs. `interactive` etc. in our component props.
I checked current uses across our projects and found there to be minimal use of these props at the moment, so we might as well change them now. I will fix the breaking projects shortly.