### PR TITLE
feat(Table): Refactor, `pageSize` is now controlled outside of the component (#557)

### DIFF
--- a/cypress/integration/Table.ts
+++ b/cypress/integration/Table.ts
@@ -1,6 +1,6 @@
 describe('Table', () => {
   it('renders properly with Gold Light theme', () => {
-    cy.visitStory({ storyId: 'elements-table--controlled-pagination', themeId: 'GoldLight' });
+    cy.visitStory({ storyId: 'elements-table--with-pagination', themeId: 'GoldLight' });
     cy.clock();
 
     cy.get('[data-testid="table.row0.col1.td"]').should('contain.text', '16 Hello');
@@ -33,7 +33,7 @@ describe('Table', () => {
   });
 
   it('renders properly with Gold Dark theme', () => {
-    cy.visitStory({ storyId: 'elements-table--controlled-pagination', themeId: 'GoldDark' });
+    cy.visitStory({ storyId: 'elements-table--with-pagination', themeId: 'GoldDark' });
     cy.percySnapshot('Table with Gold Dark theme');
   });
 

--- a/cypress/integration/Table.ts
+++ b/cypress/integration/Table.ts
@@ -1,6 +1,6 @@
 describe('Table', () => {
   it('renders properly with Gold Light theme', () => {
-    cy.visitStory({ storyId: 'elements-table--with-pagination', themeId: 'GoldLight' });
+    cy.visitStory({ storyId: 'elements-table--controlled-with-pagination', themeId: 'GoldLight' });
     cy.clock();
 
     cy.get('[data-testid="table.row0.col1.td"]').should('contain.text', '16 Hello');
@@ -33,7 +33,7 @@ describe('Table', () => {
   });
 
   it('renders properly with Gold Dark theme', () => {
-    cy.visitStory({ storyId: 'elements-table--with-pagination', themeId: 'GoldDark' });
+    cy.visitStory({ storyId: 'elements-table--controlled-with-pagination', themeId: 'GoldDark' });
     cy.percySnapshot('Table with Gold Dark theme');
   });
 

--- a/src/components/Table/component.stories.tsx
+++ b/src/components/Table/component.stories.tsx
@@ -54,7 +54,7 @@ export const Interactive = () => (
   </Card>
 );
 
-export const WithPagination = () => {
+export const ControlledWithPagination = () => {
   const [pageIndex, setPageIndex] = useState(5);
   const pageSize = 3;
 

--- a/src/components/Table/component.stories.tsx
+++ b/src/components/Table/component.stories.tsx
@@ -48,21 +48,16 @@ export const NoHeader = () => (
   </Card>
 );
 
-export const NoPagination = () => (
+export const Interactive = () => (
   <Card variant="bare">
-    <Table data={data} columns={columns} />
+    <Table data={data} columns={columns} interactive />
   </Card>
 );
 
-export const AutomaticPagination = () => (
-  <Card variant="bare">
-    <Table data={data} columns={columns} hasPagination />
-  </Card>
-);
-
-export const ControlledPagination = () => {
+export const WithPagination = () => {
   const [pageIndex, setPageIndex] = useState(5);
   const pageSize = 3;
+
   return (
     <Card variant="bare">
       <Table
@@ -71,16 +66,10 @@ export const ControlledPagination = () => {
         hasPagination
         pageSize={pageSize}
         pageCount={Math.ceil(data.length / pageSize)}
-        initialPageIndex={pageIndex}
-        onPageIndexChange={({ pageIndex }) => setPageIndex(pageIndex)}
+        pageIndex={pageIndex}
+        setPageIndex={({ pageIndex }) => setPageIndex(pageIndex)}
         data-testid="table"
       />
     </Card>
   );
 };
-
-export const Interactive = () => (
-  <Card variant="bare">
-    <Table data={data} columns={columns} interactive />
-  </Card>
-);

--- a/src/components/Table/component.stories.tsx
+++ b/src/components/Table/component.stories.tsx
@@ -67,7 +67,7 @@ export const ControlledWithPagination = () => {
         pageSize={pageSize}
         pageCount={Math.ceil(data.length / pageSize)}
         pageIndex={pageIndex}
-        setPageIndex={({ pageIndex }) => setPageIndex(pageIndex)}
+        onPageIndexChange={({ pageIndex }) => setPageIndex(pageIndex)}
         data-testid="table"
       />
     </Card>

--- a/src/components/Table/component.tsx
+++ b/src/components/Table/component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useCallback, useEffect } from 'react';
 import { useTable, TableOptions, usePagination } from 'react-table';
 
 import { Button } from '../Button';
@@ -22,24 +22,24 @@ import {
 export type Props<Data extends object> = Testable & {
   data: TableOptions<Data>['data'];
   columns: TableOptions<Data>['columns'];
-  initialPageIndex?: number;
+  pageIndex?: number;
   pageSize?: number;
   pageCount?: number;
   hasPagination?: boolean;
   hasHeader?: boolean;
   interactive?: boolean;
-  onPageIndexChange?: (params: { pageIndex: number }) => void;
+  setPageIndex?: (params: { pageIndex: number }) => void;
 };
 
 export const Component = <Data extends object>({
   data,
   columns,
-  initialPageIndex = 0,
+  pageIndex = 0,
   pageSize = 10,
   hasPagination = false,
   hasHeader = true,
   interactive = false,
-  onPageIndexChange,
+  setPageIndex,
   'data-testid': testId,
   ...otherProps
 }: Props<Data>) => {
@@ -57,22 +57,24 @@ export const Component = <Data extends object>({
     prepareRow,
     page,
     rows,
-    canPreviousPage,
-    canNextPage,
     pageOptions,
     pageCount,
-    gotoPage,
-    nextPage,
-    previousPage,
-    setPageSize,
-    state: { pageIndex },
   } = useTable(
     {
       columns,
       data,
-      initialState: { pageIndex: initialPageIndex, pageSize },
+      initialState: { pageIndex, pageSize },
       manualPagination: isControlled,
-      pageCount: isControlled ? otherProps.pageCount : Math.ceil(data.length / pageSize),
+      pageCount: otherProps.pageCount,
+      useControlledState: (state) => {
+        return React.useMemo(
+          () => ({
+            ...state,
+            pageIndex,
+          }),
+          [state],
+        );
+      },
     },
     usePagination,
   );
@@ -90,19 +92,18 @@ export const Component = <Data extends object>({
     [pageOptions, pageCount, pageIndex],
   );
 
+  const navigate = useCallback(
+    (page: number) => {
+      setPageIndex?.({ pageIndex: page });
+    },
+    [setPageIndex],
+  );
+
   useEffect(() => {
     if (isControlled && pageIndex !== 0 && pageIndex >= pageCount) {
-      gotoPage(0);
-      return;
+      navigate(0);
     }
-
-    onPageIndexChange?.({ pageIndex });
-  }, [isControlled, pageCount, pageIndex, onPageIndexChange, gotoPage]);
-
-  useEffect(() => {
-    if (!pageSize) return;
-    setPageSize(pageSize);
-  }, [pageSize, setPageSize]);
+  }, [isControlled, pageCount, pageIndex, navigate]);
 
   return (
     <Container data-testid={buildTestId()}>
@@ -123,7 +124,7 @@ export const Component = <Data extends object>({
           )}
 
           <tbody {...getTableBodyProps()}>
-            {(hasPagination ? page : rows).map((row) => {
+            {(isControlled ? page : rows).map((row) => {
               prepareRow(row);
               return (
                 <TbodyTr {...row.getRowProps()} interactive={interactive}>
@@ -148,8 +149,8 @@ export const Component = <Data extends object>({
           <PaginationWrapper>
             <Button
               variant="secondary"
-              onClick={previousPage}
-              disabled={!canPreviousPage}
+              onClick={() => navigate(pageIndex - 1)}
+              disabled={pageIndex === 0}
               shape="square"
               size="increased"
               data-testid={buildTestIdPagination('previous-btn')}
@@ -160,7 +161,7 @@ export const Component = <Data extends object>({
               <React.Fragment key={page}>
                 <PageNumberButton
                   variant={page === pageIndex ? 'primary' : 'secondary'}
-                  onClick={() => gotoPage(page)}
+                  onClick={() => navigate(page)}
                   shape="fit"
                   size="increased"
                   data-testid={buildTestIdPagination(`go-to-${page}-btn`)}
@@ -177,8 +178,8 @@ export const Component = <Data extends object>({
             ))}
             <Button
               variant="secondary"
-              onClick={nextPage}
-              disabled={!canNextPage}
+              onClick={() => navigate(pageIndex + 1)}
+              disabled={pageIndex + 1 === pageCount}
               shape="square"
               size="increased"
               data-testid={buildTestIdPagination('next-btn')}

--- a/src/components/Table/component.tsx
+++ b/src/components/Table/component.tsx
@@ -28,7 +28,7 @@ export type Props<Data extends object> = Testable & {
   hasPagination?: boolean;
   hasHeader?: boolean;
   interactive?: boolean;
-  setPageIndex?: (params: { pageIndex: number }) => void;
+  onPageIndexChange?: (params: { pageIndex: number }) => void;
 };
 
 export const Component = <Data extends object>({
@@ -39,7 +39,7 @@ export const Component = <Data extends object>({
   hasPagination = false,
   hasHeader = true,
   interactive = false,
-  setPageIndex,
+  onPageIndexChange,
   'data-testid': testId,
   ...otherProps
 }: Props<Data>) => {
@@ -94,9 +94,9 @@ export const Component = <Data extends object>({
 
   const navigate = useCallback(
     (page: number) => {
-      setPageIndex?.({ pageIndex: page });
+      onPageIndexChange?.({ pageIndex: page });
     },
-    [setPageIndex],
+    [onPageIndexChange],
   );
 
   useEffect(() => {

--- a/src/cypress/Table.stories.tsx
+++ b/src/cypress/Table.stories.tsx
@@ -102,7 +102,7 @@ export const Default = () => {
         pageIndex={pageIndex}
         pageSize={pageSize}
         pageCount={Math.ceil(fullData.length / pageSize)}
-        setPageIndex={updateData}
+        onPageIndexChange={updateData}
         data-testid={'table'}
       />
     </Card>

--- a/src/cypress/Table.stories.tsx
+++ b/src/cypress/Table.stories.tsx
@@ -10,7 +10,7 @@ export default {
 };
 
 export const Default = () => {
-  const PAGE_SIZE = 10;
+  const pageSize = 10;
 
   const options = [
     {
@@ -24,6 +24,7 @@ export const Default = () => {
   ];
 
   const [selected, setSelected] = useState<{ index: number; value: React.ReactNode }>(options[0]);
+  const [pageIndex, setPageIndex] = React.useState(6);
 
   const fullData = useMemo(
     () =>
@@ -43,7 +44,7 @@ export const Default = () => {
     [selected.index],
   );
 
-  const [data, setData] = React.useState(fullData);
+  const [data, setData] = React.useState(fullData.slice(0, pageSize));
 
   const columns = [
     {
@@ -59,6 +60,7 @@ export const Default = () => {
           <Dropdown.Item
             onClick={() => {
               setSelected(options[0]);
+              updateData({ pageIndex: 0 });
             }}
             selected={selected.index === 0}
             data-testid="option-0"
@@ -68,6 +70,7 @@ export const Default = () => {
           <Dropdown.Item
             onClick={() => {
               setSelected(options[1]);
+              updateData({ pageIndex: 0 });
             }}
             selected={selected.index === 1}
             data-testid="option-1"
@@ -82,8 +85,9 @@ export const Default = () => {
 
   const updateData = useCallback(
     ({ pageIndex }) => {
-      const start = PAGE_SIZE * pageIndex;
-      const end = start + PAGE_SIZE;
+      const start = pageSize * pageIndex;
+      const end = start + pageSize;
+      setPageIndex(pageIndex);
       setData(fullData.slice(start, end));
     },
     [fullData],
@@ -95,10 +99,10 @@ export const Default = () => {
         data={data}
         columns={columns}
         hasPagination
-        pageSize={PAGE_SIZE}
-        pageCount={Math.ceil(fullData.length / PAGE_SIZE)}
-        initialPageIndex={6}
-        onPageIndexChange={updateData}
+        pageIndex={pageIndex}
+        pageSize={pageSize}
+        pageCount={Math.ceil(fullData.length / pageSize)}
+        setPageIndex={updateData}
         data-testid={'table'}
       />
     </Card>


### PR DESCRIPTION
Issue [#557](https://github.com/binance-chain/ui-project-management/issues/557).

Uncontrolled:
Nothing has changed, but you cannot have pagination in an uncontrolled component ("automatic pagination" is no longer supported, but is not used in any of our projects).

Controlled:
- `pageSize` is now a controlled prop. This allows us to manually set the page (like reset to page 0 is needed for `Leaderboard`).
- `onPageIndexChange` -> `setPageIndex`, must update your local `pageSize` state in this callback. `setPageIndex` is only called when the user navigates using pagination.

**These changes break existing table uses (only staking I think?).**