### PR TITLE
fix(Header): Hamburger menu should not be shown if there are no items in the drawer (#663)

### DIFF
--- a/cypress/integration/Header.ts
+++ b/cypress/integration/Header.ts
@@ -172,4 +172,11 @@ describe('Header', () => {
         expect(children[0]).to.have.attr('data-testid', 'light.non-collapsible.sm');
       });
   });
+
+  it('hamburger menu should not be shown if drawer has no elements', () => {
+    cy.customViewport({ size: 'md' });
+    cy.visitStory({ storyId: 'elements-header--default', themeId: 'GoldLight' });
+
+    cy.get('[data-testid="light.header.menu"]').should('not.exist');
+  });
 });

--- a/src/components/Header/HeaderDrawer/component.tsx
+++ b/src/components/Header/HeaderDrawer/component.tsx
@@ -108,6 +108,10 @@ export const Component = ({
     });
   }, [items, activePanel, stopPropagation, clickPanelItem]);
 
+  if (panels.length === 0) {
+    return null;
+  }
+
   return (
     <>
       <Item showBorder={false} onClick={onClose} isMenu data-testid={buildTestId('menu')}>

--- a/src/components/Header/component.stories.tsx
+++ b/src/components/Header/component.stories.tsx
@@ -45,24 +45,13 @@ export const Default = () => (
     logo={<Header.Logo />}
     left={[
       {
-        element: 'Left Item 1',
+        element: 'Item 1',
       },
       {
-        element: 'Left Item 2',
+        element: 'Item 2',
       },
       {
-        element: 'Left Item 3',
-      },
-    ]}
-    right={[
-      {
-        element: 'Right Item 1',
-      },
-      {
-        element: 'Right Item 2',
-      },
-      {
-        element: 'Right Item 3',
+        element: 'Item 3',
       },
     ]}
   />


### PR DESCRIPTION
Issue [#663](https://github.com/binance-chain/ui-project-management/issues/663).

This is a bug. If you have a header with no right items, on a medium screen the hamburger menu is still shown. Test added and story example changed to prevent the issue from happening again.