### PR TITLE
feat(Tooltip): Expose `Target` and some Tippy props, fix some styling

### DIFF
--- a/src/components/Tooltip/DefaultTarget/index.tsx
+++ b/src/components/Tooltip/DefaultTarget/index.tsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 
+import { styleless } from '../../Styleless';
+
 export const DefaultTarget = styled.div`
+  ${styleless};
+
   :focus,
   :hover,
   :active {

--- a/src/components/Tooltip/component.stories.tsx
+++ b/src/components/Tooltip/component.stories.tsx
@@ -135,7 +135,7 @@ export const Variants = () => {
 };
 
 const FixedHeight = styled.div`
-  height: 3em;
+  height: 4em;
 `;
 
 export const MixedThemes = () => {
@@ -146,22 +146,19 @@ export const MixedThemes = () => {
           <div />
         </Tooltip>
       </HoneycombThemeProvider>
-      <FixedHeight />
       <HoneycombThemeProvider variant="dark">
         <Tooltip content="Dark theme." visible arrow={true} shape="fit">
-          <div />
+          <FixedHeight />
         </Tooltip>
       </HoneycombThemeProvider>
-      <FixedHeight />
       <HoneycombThemeProvider variant="light">
         <Tooltip content="Light accent theme." variant="accent" visible arrow={true} shape="fit">
-          <div />
+          <FixedHeight />
         </Tooltip>
       </HoneycombThemeProvider>
-      <FixedHeight />
       <HoneycombThemeProvider variant="dark">
         <Tooltip content="Dark accent theme." variant="accent" visible arrow={true} shape="fit">
-          <div />
+          <FixedHeight />
         </Tooltip>
       </HoneycombThemeProvider>
     </>

--- a/src/components/Tooltip/component.stories.tsx
+++ b/src/components/Tooltip/component.stories.tsx
@@ -50,6 +50,10 @@ const Label = styled.div`
 `;
 
 const PlacementContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: end;
+
   > *:not(:last-child) {
     margin-right: ${({ theme }) => em(theme.honeycomb.size.normal)};
   }

--- a/src/components/Tooltip/component.stories.tsx
+++ b/src/components/Tooltip/component.stories.tsx
@@ -51,8 +51,7 @@ const Label = styled.div`
 
 const PlacementContainer = styled.div`
   display: flex;
-  flex-direction: row;
-  align-items: end;
+  align-items: center;
 
   > *:not(:last-child) {
     margin-right: ${({ theme }) => em(theme.honeycomb.size.normal)};

--- a/src/components/Tooltip/component.tsx
+++ b/src/components/Tooltip/component.tsx
@@ -11,19 +11,19 @@ export type TriggerValue = 'mouseenter' | 'click' | 'manual';
 export type Props = Pick<React.HTMLProps<HTMLElement>, 'children' | 'style'> &
   Pick<
     React.ComponentProps<typeof Tippy>,
+    | 'appendTo'
     | 'arrow'
     | 'className'
-    | 'onShow'
-    | 'onHide'
-    | 'visible'
     | 'disabled'
     | 'hideOnClick'
     | 'interactive'
-    | 'reference'
-    | 'placement'
-    | 'onClickOutside'
     | 'maxWidth'
-    | 'appendTo'
+    | 'onClickOutside'
+    | 'onHide'
+    | 'onShow'
+    | 'placement'
+    | 'reference'
+    | 'visible'
   > &
   Testable & {
     content: React.ReactNode;

--- a/src/components/Tooltip/component.tsx
+++ b/src/components/Tooltip/component.tsx
@@ -23,6 +23,7 @@ export type Props = Pick<React.HTMLProps<HTMLElement>, 'children' | 'style'> &
     | 'placement'
     | 'onClickOutside'
     | 'maxWidth'
+    | 'appendTo'
   > &
   Testable & {
     content: React.ReactNode;

--- a/src/components/Tooltip/component.tsx
+++ b/src/components/Tooltip/component.tsx
@@ -22,6 +22,7 @@ export type Props = Pick<React.HTMLProps<HTMLElement>, 'children' | 'style'> &
     | 'reference'
     | 'placement'
     | 'onClickOutside'
+    | 'maxWidth'
   > &
   Testable & {
     content: React.ReactNode;

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,11 +1,13 @@
 import { Component } from './component';
 import { DefaultTarget } from './DefaultTarget';
-import { Content } from './styled';
+import { Content, Target } from './styled';
 
 export const Tooltip = Component as typeof Component & {
   Content: typeof Content;
+  Target: typeof Target;
   DefaultTarget: typeof DefaultTarget;
 };
 
 Tooltip.Content = Content;
+Tooltip.Target = Target;
 Tooltip.DefaultTarget = DefaultTarget;

--- a/src/components/Tooltip/styled.tsx
+++ b/src/components/Tooltip/styled.tsx
@@ -6,6 +6,7 @@ import tippyAnimations from '../../../node_modules/tippy.js/animations/shift-awa
 import { boxSizing } from '../../modules/box-sizing';
 import { GoldDark } from '../../modules/themes/themes/GoldDark';
 import { GoldLight } from '../../modules/themes/themes/GoldLight';
+import { fit } from '../internal/Shape';
 
 export const SIZES = ['reduced', 'small', 'tiny', 'micro', 'none'] as const;
 export type Size = typeof SIZES[number];
@@ -70,11 +71,7 @@ export const Styles = createGlobalStyle<{ variant: Variant }>`
 `;
 
 export const Target = styled.div<{ shape?: Shape }>`
-  ${({ shape }) =>
-    shape === 'fit' &&
-    css`
-      display: inline-block;
-    `};
+  ${({ shape }) => shape === 'fit' && fit};
 `;
 
 export const Content = styled.div<{ padding: Size; radius: Radius; variant: Variant }>`


### PR DESCRIPTION
Found this issue in the browser extension that it's really difficult to align tooltip items because of the component design. This PR fixes things.
