### PR TITLE
fix(Header): Non-collapsible on SM items appearing in both header and drawer

### DIFF
--- a/cypress/integration/Header.ts
+++ b/cypress/integration/Header.ts
@@ -130,6 +130,7 @@ describe('Header', () => {
     cy.get('[data-testid="light.header.non-collapsible"]')
       .children()
       .then((children) => {
+        expect(children.length).to.equal(3);
         expect(children[0]).to.have.attr('data-testid', 'light.non-collapsible');
         expect(children[1]).to.have.attr('data-testid', 'light.non-collapsible.md');
         expect(children[2]).to.have.attr('data-testid', 'light.non-collapsible.sm');
@@ -142,6 +143,7 @@ describe('Header', () => {
     cy.get('[data-testid="light.header.non-collapsible"]')
       .children()
       .then((children) => {
+        expect(children.length).to.equal(2);
         expect(children[0]).to.have.attr('data-testid', 'light.non-collapsible');
         expect(children[1]).to.have.attr('data-testid', 'light.non-collapsible.sm');
       });
@@ -158,6 +160,7 @@ describe('Header', () => {
     cy.get('[data-testid="light.header.non-collapsible"]')
       .children()
       .then((children) => {
+        expect(children.length).to.equal(1);
         expect(children[0]).to.have.attr('data-testid', 'light.non-collapsible');
       });
     cy.get('[data-testid="light.header.menu"]').click();

--- a/src/components/Header/component.tsx
+++ b/src/components/Header/component.tsx
@@ -135,11 +135,11 @@ export const Component = ({
     if (!nonCollapsible || nonCollapsible.length === 0) return null;
 
     let items = nonCollapsible;
-    if (isSm && !isMd) {
-      items = nonCollapsible.filter((it) => !it.collapseOn);
-    }
     if (isMd) {
       items = nonCollapsible.filter((it) => !it.collapseOn || it.collapseOn === 'sm');
+    }
+    if (isSm) {
+      items = nonCollapsible.filter((it) => !it.collapseOn);
     }
 
     return <NonCollapsibleHeaderItems items={items} data-testid={buildTestId('non-collapsible')} />;


### PR DESCRIPTION
Fix bad bug where non-collapsible SM items aren't hidden correctly, so they appear on both the header and drawer.

<img width="704" alt="image" src="https://user-images.githubusercontent.com/15721063/103612048-7743a300-4f88-11eb-8bd8-43ebdf3aca47.png">

<img width="729" alt="image" src="https://user-images.githubusercontent.com/15721063/103612067-8165a180-4f88-11eb-8449-71f61068f82a.png">

After fix:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/15721063/103612213-d1dcff00-4f88-11eb-8d39-838e80f9d53a.png">

