### PR TITLE
fix(TextInput): Pristine state should be removed if the input has a value (#751)

### DIFF
--- a/src/components/TextInput/component.tsx
+++ b/src/components/TextInput/component.tsx
@@ -111,7 +111,6 @@ export const Component = ({
 
   const change = useCallback<NonNullable<Props['onChange']>>(
     (evt) => {
-      setIsPristine(false);
       onChange?.(evt);
     },
     [onChange],

--- a/src/components/TextInput/component.tsx
+++ b/src/components/TextInput/component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { nanoid } from 'nanoid';
 
 import { Size } from '../internal/Size';
@@ -80,6 +80,12 @@ export const Component = ({
       }
     }
   }, [value]);
+
+  useEffect(() => {
+    if (!isPristine) return;
+
+    setIsPristine(!value);
+  }, [value, isPristine]);
 
   useLayoutEffect(() => {
     if (!dynamic) return;


### PR DESCRIPTION
Issue [#751](https://github.com/binance-chain/ui-project-management/issues/751).