### PR TITLE
fix(PasswordInput): Add `type` attribute so button isn't pressed when input is used in a form (#733)

### DIFF
--- a/src/components/PasswordInput/component.tsx
+++ b/src/components/PasswordInput/component.tsx
@@ -51,6 +51,7 @@ export const Component = ({
         <Styleless
           data-testid={buildTestId('toggle-show')}
           htmlTag="button"
+          type="button"
           onClick={() => setShouldDisplay(!shouldDisplay)}
           style={{ fontSize: theme.honeycomb.size.increased }}
         >


### PR DESCRIPTION
Issue [#733](https://github.com/binance-chain/ui-project-management/issues/733).