### PR TITLE
feat: Create `Swiper` component (#792)

### DIFF
--- a/cypress/integration/Swiper.ts
+++ b/cypress/integration/Swiper.ts
@@ -1,0 +1,60 @@
+describe('Swiper', () => {
+  const checkSm = ({ theme, index }: {
+    theme: 'accent' | 'light' | 'dark',
+    index: number,
+  }) => {
+    cy.get(`[data-testid="${theme}.swiper.pagination"]`)
+    .children()
+    .then((children) => {
+      children[index].click();
+
+      cy.get(`[data-testid="${theme}.swiper.item-${index}.label"]`).should('be.visible');
+      cy.get(`[data-testid="${theme}.swiper.item-${index}.label"]`).should('have.text', index + 1);
+    });
+  };
+
+  it('renders correctly on small screens', () => {
+    cy.customViewport({ size: 'sm' });
+    cy.clock();
+    cy.visitStory({ storyId: 'elements-swiper--default', themeId: 'GoldLight' });
+
+    checkSm({
+      theme: 'accent',
+      index: 0,
+    })
+    checkSm({
+      theme: 'dark',
+      index: 1,
+    })
+    checkSm({
+      theme: 'light',
+      index: 4,
+    })
+    cy.tick(10000);
+
+    cy.percySnapshot('Swiper while open on a small screen');
+  });
+
+  it('renders correctly on medium screens', () => {
+    cy.customViewport({ size: 'md' });
+    cy.clock();
+    cy.visitStory({ storyId: 'elements-swiper--default', themeId: 'GoldLight' });
+
+    cy.get('[data-testid="accent.swiper.btn-next"]').should('be.visible');
+    cy.get('[data-testid="accent.swiper.btn-prev"]').should('not.be.visible');
+
+    cy.get('[data-testid="dark.swiper.btn-next"]').click();
+    cy.tick(10000);
+    cy.get('[data-testid="dark.swiper.btn-next"]').should('be.visible');
+    cy.get('[data-testid="dark.swiper.btn-prev"]').should('be.visible');
+
+    for (let i = 0; i < 3; i++) {
+      cy.get('[data-testid="light.swiper.btn-next"]').click();
+      cy.tick(10000);
+    }
+    cy.get('[data-testid="light.swiper.btn-next"]').should('not.be.visible');
+    cy.get('[data-testid="light.swiper.btn-prev"]').should('be.visible');
+
+    cy.percySnapshot('Swiper while open on a medium screen', { widths: [768] });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -44,15 +44,15 @@
     }
   },
   "devDependencies": {
-    "@babel/core": "^7.10.4",
+    "@babel/core": "^7.12.10",
     "@binance-chain/prettier-config": "^1.0.1",
     "@percy/cypress": "^2.3.0",
     "@rollup/plugin-image": "^2.0.5",
     "@rollup/plugin-url": "^5.0.1",
-    "@storybook/addon-essentials": "^6.1.10",
-    "@storybook/addons": "^6.1.10",
+    "@storybook/addon-essentials": "^6.1.14",
+    "@storybook/addons": "^6.1.14",
     "@storybook/preset-typescript": "^3.0.0",
-    "@storybook/react": "^6.1.10",
+    "@storybook/react": "^6.1.14",
     "@svgr/rollup": "^5.4.0",
     "@svgr/webpack": "^5.4.0",
     "@types/crypto-js": "^3.1.47",
@@ -92,9 +92,9 @@
     "polished": "^3.6.5",
     "qrcode.react": "^1.0.0",
     "query-string": "^6.13.1",
-    "rc-table": "^7.8.4",
     "react-spring": "^8.0.27",
-    "react-table": "^7.6.0"
+    "react-table": "^7.6.0",
+    "swiper": "^6.4.5"
   },
   "resolutions": {
     "@types/react": "16.9.35"

--- a/src/components/Swiper/Item/component.tsx
+++ b/src/components/Swiper/Item/component.tsx
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react';
+import { SwiperSlide } from 'swiper/react';
+
+import { useBuildTestId, Testable } from '../../../modules/test-ids';
+import { Context } from '../context';
+
+export type Props = React.ComponentProps<typeof SwiperSlide> & Testable;
+
+export const Component = ({ 'data-testid': testId, ...otherProps }: Props) => {
+  const { testId: parentTestId } = useContext(Context);
+  const { buildTestId } = useBuildTestId({
+    id: testId ? parentTestId : undefined,
+  });
+
+  return <SwiperSlide {...otherProps} data-testid={buildTestId(testId)} />;
+};
+
+// The `swiper` code uses `displayName` to render slides correctly, so we cannot change it.
+Component.displayName = 'SwiperSlide';

--- a/src/components/Swiper/Item/index.tsx
+++ b/src/components/Swiper/Item/index.tsx
@@ -1,0 +1,1 @@
+export { Component as Item } from './component';

--- a/src/components/Swiper/component.stories.tsx
+++ b/src/components/Swiper/component.stories.tsx
@@ -20,10 +20,6 @@ const Container = styled.div`
   position: relative;
   display: flex;
   color: ${({ theme }) => theme.honeycomb.color.text.masked};
-
-  > img {
-    width: 100%;
-  }
 `;
 
 const Label = styled.div`
@@ -44,7 +40,7 @@ export const Default = () => {
       {new Array(5).fill(null).map((_, index) => (
         <Swiper.Item data-testid={buildTestId(`item-${index}`)}>
           <Container>
-            <img alt="" src={placeholder} />
+            <img alt="" src={placeholder} width="100%" />
             <Label data-testid={buildTestId(`item-${index}.label`)}>{index + 1}</Label>
           </Container>
         </Swiper.Item>

--- a/src/components/Swiper/component.stories.tsx
+++ b/src/components/Swiper/component.stories.tsx
@@ -4,6 +4,7 @@ import { em } from 'polished';
 
 import { decorators } from '../../modules/decorators';
 import { Sections } from '../../modules/sections';
+import { useBuildTestId } from '../../modules/test-ids';
 
 import placeholder from './placeholder.svg';
 
@@ -36,13 +37,15 @@ const Label = styled.div`
 `;
 
 export const Default = () => {
+  const { buildTestId } = useBuildTestId({ id: 'swiper' });
+
   return (
-    <Swiper data-testid="swiper">
+    <Swiper data-testid={buildTestId()}>
       {new Array(5).fill(null).map((_, index) => (
-        <Swiper.Item data-testid={`item-${index}`}>
+        <Swiper.Item data-testid={buildTestId(`item-${index}`)}>
           <Container>
             <img alt="" src={placeholder} />
-            <Label>{index + 1}</Label>
+            <Label data-testid={buildTestId(`item-${index}.label`)}>{index + 1}</Label>
           </Container>
         </Swiper.Item>
       ))}

--- a/src/components/Swiper/component.stories.tsx
+++ b/src/components/Swiper/component.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import { em } from 'polished';
+
+import { decorators } from '../../modules/decorators';
+import { Sections } from '../../modules/sections';
+
+import placeholder from './placeholder.svg';
+
+import { Swiper } from './';
+
+export default {
+  component: Swiper,
+  decorators,
+  title: `${Sections.Elements}/Swiper`,
+};
+
+const Container = styled.div`
+  position: relative;
+  display: flex;
+  color: ${({ theme }) => theme.honeycomb.color.text.primary};
+`;
+
+const Label = styled.div`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: ${({ theme }) => em(theme.honeycomb.size.huge)};
+`;
+
+export const Default = () => {
+  return (
+    <Swiper data-testid="swiper">
+      {new Array(5).fill(null).map((_, index) => (
+        <Swiper.Item data-testid={`item-${index}`}>
+          <Container>
+            <img alt="" src={placeholder} />
+            <Label>{index + 1}</Label>
+          </Container>
+        </Swiper.Item>
+      ))}
+    </Swiper>
+  );
+};

--- a/src/components/Swiper/component.stories.tsx
+++ b/src/components/Swiper/component.stories.tsx
@@ -18,7 +18,11 @@ export default {
 const Container = styled.div`
   position: relative;
   display: flex;
-  color: ${({ theme }) => theme.honeycomb.color.text.primary};
+  color: ${({ theme }) => theme.honeycomb.color.text.masked};
+
+  > img {
+    width: 100%;
+  }
 `;
 
 const Label = styled.div`
@@ -28,7 +32,7 @@ const Label = styled.div`
   justify-content: center;
   width: 100%;
   height: 100%;
-  font-size: ${({ theme }) => em(theme.honeycomb.size.huge)};
+  font-size: ${({ theme }) => em(theme.honeycomb.size.increased)};
 `;
 
 export const Default = () => {

--- a/src/components/Swiper/component.tsx
+++ b/src/components/Swiper/component.tsx
@@ -1,13 +1,20 @@
 import React, { useMemo } from 'react';
+import SwiperCore, { Navigation } from 'swiper';
 import { Swiper } from 'swiper/react';
 
 import { Testable, useBuildTestId } from '../../modules/test-ids';
 import '../../../node_modules/swiper/swiper.min.css';
+import '../../../node_modules/swiper/components/navigation/navigation.min.css';
 
 import { Context } from './context';
 import { MARGIN_WIDTH, Styled } from './styled';
 
-export type Props = Omit<React.ComponentProps<typeof Swiper>, 'slidesPerView' | 'spaceBetween'> &
+SwiperCore.use([Navigation]);
+
+export type Props = Omit<
+  React.ComponentProps<typeof Swiper>,
+  'navigation' | 'slidesPerView' | 'spaceBetween'
+> &
   Testable & {
     children: React.ReactNode;
   };
@@ -22,6 +29,7 @@ export const Component = ({ children, 'data-testid': testId, ...otherProps }: Pr
         {...otherProps}
         spaceBetween={MARGIN_WIDTH}
         slidesPerView="auto"
+        navigation
         data-testid={buildTestId()}
       >
         {children}

--- a/src/components/Swiper/component.tsx
+++ b/src/components/Swiper/component.tsx
@@ -1,0 +1,33 @@
+import React, { useMemo } from 'react';
+import { Swiper } from 'swiper/react';
+
+import { Testable, useBuildTestId } from '../../modules/test-ids';
+import '../../../node_modules/swiper/swiper.min.css';
+
+import { Context } from './context';
+import { MARGIN_WIDTH, Styled } from './styled';
+
+export type Props = Omit<React.ComponentProps<typeof Swiper>, 'slidesPerView' | 'spaceBetween'> &
+  Testable & {
+    children: React.ReactNode;
+  };
+
+export const Component = ({ children, 'data-testid': testId, ...otherProps }: Props) => {
+  const { buildTestId } = useBuildTestId({ id: testId });
+  const context = useMemo(() => ({ testId }), [testId]);
+
+  return (
+    <Context.Provider value={context}>
+      <Styled
+        {...otherProps}
+        spaceBetween={MARGIN_WIDTH}
+        slidesPerView="auto"
+        data-testid={buildTestId()}
+      >
+        {children}
+      </Styled>
+    </Context.Provider>
+  );
+};
+
+Component.displayName = 'Swiper';

--- a/src/components/Swiper/component.tsx
+++ b/src/components/Swiper/component.tsx
@@ -1,29 +1,23 @@
 import React, { useMemo } from 'react';
-import SwiperCore, { Navigation } from 'swiper';
+import SwiperCore, { Navigation, Pagination } from 'swiper';
 import { Swiper } from 'swiper/react';
 
 import { Testable, useBuildTestId } from '../../modules/test-ids';
-import { SIZES, useWindowSize } from '../internal/useWindowSize';
 
 import { Context } from './context';
 import { MARGIN_WIDTH, Styled, Styles } from './styled';
 
-SwiperCore.use([Navigation]);
+SwiperCore.use([Navigation, Pagination]);
 
 export type Props = Omit<
   React.ComponentProps<typeof Swiper>,
-  'navigation' | 'slidesPerView' | 'spaceBetween'
+  'navigation' | 'pagination' | 'slidesPerView' | 'spaceBetween'
 > &
-  Testable & {
-    children: React.ReactNode;
-  };
+  Testable;
 
 export const Component = ({ children, 'data-testid': testId, ...otherProps }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
   const context = useMemo(() => ({ testId }), [testId]);
-  const { width } = useWindowSize();
-
-  const isSm = useMemo(() => width < SIZES.md, [width]);
 
   return (
     <>
@@ -32,8 +26,16 @@ export const Component = ({ children, 'data-testid': testId, ...otherProps }: Pr
         <Styled
           {...otherProps}
           spaceBetween={MARGIN_WIDTH}
-          slidesPerView="auto"
-          navigation={!isSm}
+          navigation
+          pagination={{
+            clickable: true,
+          }}
+          breakpoints={{
+            // SIZES.md
+            768: {
+              slidesPerView: 'auto',
+            },
+          }}
           data-testid={buildTestId()}
         >
           {children}

--- a/src/components/Swiper/component.tsx
+++ b/src/components/Swiper/component.tsx
@@ -26,9 +26,13 @@ export const Component = ({ children, 'data-testid': testId, ...otherProps }: Pr
         <Styled
           {...otherProps}
           spaceBetween={MARGIN_WIDTH}
-          navigation
+          navigation={{
+            prevEl: '.swiper-button-prev',
+            nextEl: '.swiper-button-next',
+          }}
           pagination={{
             clickable: true,
+            el: '.swiper-pagination',
           }}
           breakpoints={{
             // SIZES.md
@@ -39,6 +43,9 @@ export const Component = ({ children, 'data-testid': testId, ...otherProps }: Pr
           data-testid={buildTestId()}
         >
           {children}
+          <div className="swiper-button-prev" data-testid={buildTestId('btn-prev')}></div>
+          <div className="swiper-button-next" data-testid={buildTestId('btn-next')}></div>
+          <div className="swiper-pagination" data-testid={buildTestId('pagination')}></div>
         </Styled>
       </Context.Provider>
     </>

--- a/src/components/Swiper/component.tsx
+++ b/src/components/Swiper/component.tsx
@@ -3,11 +3,10 @@ import SwiperCore, { Navigation } from 'swiper';
 import { Swiper } from 'swiper/react';
 
 import { Testable, useBuildTestId } from '../../modules/test-ids';
-import '../../../node_modules/swiper/swiper.min.css';
-import '../../../node_modules/swiper/components/navigation/navigation.min.css';
+import { SIZES, useWindowSize } from '../internal/useWindowSize';
 
 import { Context } from './context';
-import { MARGIN_WIDTH, Styled } from './styled';
+import { MARGIN_WIDTH, Styled, Styles } from './styled';
 
 SwiperCore.use([Navigation]);
 
@@ -22,19 +21,25 @@ export type Props = Omit<
 export const Component = ({ children, 'data-testid': testId, ...otherProps }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
   const context = useMemo(() => ({ testId }), [testId]);
+  const { width } = useWindowSize();
+
+  const isSm = useMemo(() => width < SIZES.md, [width]);
 
   return (
-    <Context.Provider value={context}>
-      <Styled
-        {...otherProps}
-        spaceBetween={MARGIN_WIDTH}
-        slidesPerView="auto"
-        navigation
-        data-testid={buildTestId()}
-      >
-        {children}
-      </Styled>
-    </Context.Provider>
+    <>
+      <Styles />
+      <Context.Provider value={context}>
+        <Styled
+          {...otherProps}
+          spaceBetween={MARGIN_WIDTH}
+          slidesPerView="auto"
+          navigation={!isSm}
+          data-testid={buildTestId()}
+        >
+          {children}
+        </Styled>
+      </Context.Provider>
+    </>
   );
 };
 

--- a/src/components/Swiper/context.tsx
+++ b/src/components/Swiper/context.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Context = React.createContext<{ testId: string | undefined }>({
+  testId: undefined,
+});

--- a/src/components/Swiper/index.tsx
+++ b/src/components/Swiper/index.tsx
@@ -1,0 +1,8 @@
+import { Component } from './component';
+import { Item } from './Item';
+
+export const Swiper = Component as typeof Component & {
+  Item: typeof Item;
+};
+
+Swiper.Item = Item;

--- a/src/components/Swiper/next.svg
+++ b/src/components/Swiper/next.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.4999 12L6.9999 18.6L8.3999 20L16.3999 12L8.3999 4L6.9999 5.4L13.4999 12Z" fill="white"/>
+</svg>

--- a/src/components/Swiper/placeholder.svg
+++ b/src/components/Swiper/placeholder.svg
@@ -1,0 +1,3 @@
+<svg width="270" height="152" viewBox="0 0 270 152" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="270" height="152" rx="8" fill="#C4C4C4"/>
+</svg>

--- a/src/components/Swiper/prev.svg
+++ b/src/components/Swiper/prev.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.5001 12L17.0001 18.6L15.6001 20L7.6001 12L15.6001 4L17.0001 5.4L10.5001 12Z" fill="white"/>
+</svg>

--- a/src/components/Swiper/styled.tsx
+++ b/src/components/Swiper/styled.tsx
@@ -1,7 +1,9 @@
-import styled, { css } from 'styled-components';
+import styled, { createGlobalStyle, css } from 'styled-components';
 import { em, transparentize } from 'polished';
 import { Swiper } from 'swiper/react';
 
+import swiper from '../../../node_modules/swiper/swiper.min.css';
+import swiperNavigation from '../../../node_modules/swiper/components/navigation/navigation.min.css';
 import { GoldDark } from '../../modules/themes/themes/GoldDark';
 
 import prev from './prev.svg';
@@ -10,6 +12,11 @@ import next from './next.svg';
 const SLIDE_WIDTH = 270;
 const SLIDE_HEIGHT = 152;
 export const MARGIN_WIDTH = 40;
+
+export const Styles = createGlobalStyle`
+  ${swiper};
+  ${swiperNavigation};
+`;
 
 const buttons = css`
   width: ${({ theme }) => em(theme.honeycomb.size.large)};

--- a/src/components/Swiper/styled.tsx
+++ b/src/components/Swiper/styled.tsx
@@ -1,16 +1,58 @@
-import styled from 'styled-components';
-import { em } from 'polished';
+import styled, { css } from 'styled-components';
+import { em, transparentize } from 'polished';
 import { Swiper } from 'swiper/react';
+
+import { GoldDark } from '../../modules/themes/themes/GoldDark';
+
+import prev from './prev.svg';
+import next from './next.svg';
 
 const SLIDE_WIDTH = 270;
 const SLIDE_HEIGHT = 152;
 export const MARGIN_WIDTH = 40;
 
+const buttons = css`
+  width: ${({ theme }) => em(theme.honeycomb.size.large)};
+  height: 100%;
+  top: 0;
+  margin: 0;
+  cursor: pointer;
+  background-color: ${transparentize(0.7, GoldDark.honeycomb.color.bg.tooltip.normal)};
+  background-repeat: no-repeat;
+  background-position: center;
+`;
+
 export const Styled = styled(Swiper)`
+  border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
+
   .swiper-slide {
     width: ${em(SLIDE_WIDTH)};
     height: ${em(SLIDE_HEIGHT)};
     border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
     overflow: hidden;
+  }
+
+  .swiper-button-prev {
+    ${buttons};
+    left: 0;
+    background-image: url(${prev});
+
+    ::after {
+      display: none;
+    }
+  }
+
+  .swiper-button-next {
+    ${buttons};
+    right: 0;
+    background-image: url(${next});
+
+    ::after {
+      display: none;
+    }
+  }
+
+  .swiper-button-disabled {
+    display: none;
   }
 `;

--- a/src/components/Swiper/styled.tsx
+++ b/src/components/Swiper/styled.tsx
@@ -4,7 +4,9 @@ import { Swiper } from 'swiper/react';
 
 import swiper from '../../../node_modules/swiper/swiper.min.css';
 import swiperNavigation from '../../../node_modules/swiper/components/navigation/navigation.min.css';
+import swiperPagination from '../../../node_modules/swiper/components/pagination/pagination.min.css';
 import { GoldDark } from '../../modules/themes/themes/GoldDark';
+import { SIZES } from '../internal/useWindowSize';
 
 import prev from './prev.svg';
 import next from './next.svg';
@@ -16,11 +18,12 @@ export const MARGIN_WIDTH = 40;
 export const Styles = createGlobalStyle`
   ${swiper};
   ${swiperNavigation};
+  ${swiperPagination};
 `;
 
 const buttons = css`
   width: ${({ theme }) => em(theme.honeycomb.size.large)};
-  height: 100%;
+  height: ${em(SLIDE_HEIGHT)};
   top: 0;
   margin: 0;
   cursor: pointer;
@@ -29,16 +32,7 @@ const buttons = css`
   background-position: center;
 `;
 
-export const Styled = styled(Swiper)`
-  border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
-
-  .swiper-slide {
-    width: ${em(SLIDE_WIDTH)};
-    height: ${em(SLIDE_HEIGHT)};
-    border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
-    overflow: hidden;
-  }
-
+const navigation = css`
   .swiper-button-prev {
     ${buttons};
     left: 0;
@@ -61,5 +55,62 @@ export const Styled = styled(Swiper)`
 
   .swiper-button-disabled {
     display: none;
+  }
+`;
+
+const pagination = css`
+  .swiper-pagination {
+    display: flex;
+    justify-content: center;
+    bottom: 0;
+
+    .swiper-pagination-bullet {
+      opacity: 1;
+      background-color: ${({ theme }) => theme.honeycomb.color.text.disabled};
+      margin: 0 ${em(2)};
+    }
+
+    .swiper-pagination-bullet-active {
+      background-color: ${({ theme }) => theme.honeycomb.color.primary.normal};
+    }
+  }
+`;
+
+export const Styled = styled(Swiper)`
+  border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
+  overflow: hidden;
+
+  .swiper-slide {
+    border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
+    overflow: hidden;
+  }
+
+  ${pagination};
+  padding-bottom: ${({ theme }) => em(theme.honeycomb.size.small)};
+
+  .swiper-button-next,
+  .swiper-button-prev {
+    display: none;
+  }
+
+  @media (min-width: ${em(SIZES.md)}) {
+    ${navigation};
+    padding-bottom: 0;
+
+    .swiper-slide {
+      width: ${em(SLIDE_WIDTH)} !important;
+      height: ${em(SLIDE_HEIGHT)} !important;
+    }
+
+    .swiper-button-next,
+    .swiper-button-prev {
+      :not(.swiper-button-disabled) {
+        display: flex;
+      }
+    }
+
+    .swiper-pagination {
+      display: none;
+    }
   }
 `;

--- a/src/components/Swiper/styled.tsx
+++ b/src/components/Swiper/styled.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import { em } from 'polished';
+import { Swiper } from 'swiper/react';
+
+const SLIDE_WIDTH = 270;
+const SLIDE_HEIGHT = 152;
+export const MARGIN_WIDTH = 40;
+
+export const Styled = styled(Swiper)`
+  .swiper-slide {
+    width: ${em(SLIDE_WIDTH)};
+    height: ${em(SLIDE_HEIGHT)};
+    border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
+    overflow: hidden;
+  }
+`;

--- a/src/components/Swiper/styled.tsx
+++ b/src/components/Swiper/styled.tsx
@@ -21,36 +21,31 @@ export const Styles = createGlobalStyle`
   ${swiperPagination};
 `;
 
-const buttons = css`
-  width: ${({ theme }) => em(theme.honeycomb.size.large)};
-  height: ${em(SLIDE_HEIGHT)};
-  top: 0;
-  margin: 0;
-  cursor: pointer;
-  background-color: ${transparentize(0.7, GoldDark.honeycomb.color.bg.tooltip.normal)};
-  background-repeat: no-repeat;
-  background-position: center;
-`;
-
 const navigation = css`
-  .swiper-button-prev {
-    ${buttons};
-    left: 0;
-    background-image: url(${prev});
+  .swiper-button-prev,
+  .swiper-button-next {
+    width: ${({ theme }) => em(theme.honeycomb.size.large)};
+    height: ${em(SLIDE_HEIGHT)};
+    top: 0;
+    margin: 0;
+    cursor: pointer;
+    background-color: ${transparentize(0.7, GoldDark.honeycomb.color.bg.tooltip.normal)};
+    background-repeat: no-repeat;
+    background-position: center;
 
     ::after {
       display: none;
     }
   }
 
+  .swiper-button-prev {
+    left: 0;
+    background-image: url(${prev});
+  }
+
   .swiper-button-next {
-    ${buttons};
     right: 0;
     background-image: url(${next});
-
-    ::after {
-      display: none;
-    }
   }
 
   .swiper-button-disabled {
@@ -88,8 +83,8 @@ export const Styled = styled(Swiper)`
   ${pagination};
   padding-bottom: ${({ theme }) => em(theme.honeycomb.size.small)};
 
-  .swiper-button-next,
-  .swiper-button-prev {
+  .swiper-button-prev,
+  .swiper-button-next {
     display: none;
   }
 
@@ -102,8 +97,8 @@ export const Styled = styled(Swiper)`
       height: ${em(SLIDE_HEIGHT)} !important;
     }
 
-    .swiper-button-next,
-    .swiper-button-prev {
+    .swiper-button-prev,
+    .swiper-button-next {
       :not(.swiper-button-disabled) {
         display: flex;
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,7 @@ export { SolidAvatar } from './components/SolidAvatar';
 export { Space } from './components/Space';
 export { Steps } from './components/Steps';
 export { Styleless, styleless } from './components/Styleless';
+export { Swiper } from './components/Swiper';
 export { Table } from './components/Table';
 export { Text } from './components/Text';
 export { TextArea } from './components/TextArea';

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,13 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
+"@babel/code-frame@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/compat-data@^7.10.4", "@babel/compat-data@^7.9.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.10.4.tgz#706a6484ee6f910b719b696a9194f8da7d7ac241"
@@ -79,7 +86,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.10.4", "@babel/core@^7.4.4", "@babel/core@^7.7.5", "@babel/core@^7.9.0":
+"@babel/core@^7.1.0", "@babel/core@^7.4.4", "@babel/core@^7.7.5", "@babel/core@^7.9.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.4.tgz#780e8b83e496152f8dd7df63892b2e052bf1d51d"
   integrity sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==
@@ -101,6 +108,27 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.10.tgz#b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd"
+  integrity sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.10"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.5"
+    "@babel/parser" "^7.12.10"
+    "@babel/template" "^7.12.7"
+    "@babel/traverse" "^7.12.10"
+    "@babel/types" "^7.12.10"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.10.4", "@babel/generator@^7.4.0", "@babel/generator@^7.9.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.4.tgz#e49eeed9fe114b62fa5b181856a43a5e32f5f243"
@@ -117,6 +145,15 @@
   integrity sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
   dependencies:
     "@babel/types" "^7.12.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.12.10", "@babel/generator@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
+  integrity sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
+  dependencies:
+    "@babel/types" "^7.12.11"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -249,12 +286,28 @@
     "@babel/template" "^7.10.4"
     "@babel/types" "^7.10.4"
 
+"@babel/helper-function-name@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz#1fd7738aee5dcf53c3ecff24f1da9c511ec47b42"
+  integrity sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.12.10"
+    "@babel/template" "^7.12.7"
+    "@babel/types" "^7.12.11"
+
 "@babel/helper-get-function-arity@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
   integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
   dependencies:
     "@babel/types" "^7.10.4"
+
+"@babel/helper-get-function-arity@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz#b158817a3165b5faa2047825dfa61970ddcc16cf"
+  integrity sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==
+  dependencies:
+    "@babel/types" "^7.12.10"
 
 "@babel/helper-hoist-variables@^7.10.4":
   version "7.10.4"
@@ -414,10 +467,22 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
+"@babel/helper-split-export-declaration@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz#1b4cc424458643c47d37022223da33d76ea4603a"
+  integrity sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==
+  dependencies:
+    "@babel/types" "^7.12.11"
+
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+
+"@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
 "@babel/helper-validator-option@^7.12.1":
   version "7.12.1"
@@ -465,6 +530,11 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.4.tgz#9eedf27e1998d87739fb5028a5120557c06a1a64"
   integrity sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==
+
+"@babel/parser@^7.12.10", "@babel/parser@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
+  integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
 
 "@babel/parser@^7.12.3", "@babel/parser@^7.12.7":
   version "7.12.7"
@@ -1912,13 +1982,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.1":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
-  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
@@ -1974,6 +2037,21 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.12.10":
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.12.tgz#d0cd87892704edd8da002d674bc811ce64743376"
+  integrity sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==
+  dependencies:
+    "@babel/code-frame" "^7.12.11"
+    "@babel/generator" "^7.12.11"
+    "@babel/helper-function-name" "^7.12.11"
+    "@babel/helper-split-export-declaration" "^7.12.11"
+    "@babel/parser" "^7.12.11"
+    "@babel/types" "^7.12.12"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/traverse@^7.12.9":
   version "7.12.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.9.tgz#fad26c972eabbc11350e0b695978de6cc8e8596f"
@@ -2004,6 +2082,15 @@
   integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12":
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
+  integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
@@ -2800,7 +2887,7 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
-"@popperjs/core@^2.4.4", "@popperjs/core@^2.5.4":
+"@popperjs/core@^2.5.4":
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
   integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
@@ -2962,17 +3049,17 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
-"@storybook/addon-actions@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.1.10.tgz#3742c316e914e2aef661a132e4d7e6c334e89997"
-  integrity sha512-fbt1v9Ms8g/gQC8cQ7p5qZdR5vrc3qv6el/x7M6xUhq4lBjw4NOHIhBBDhaPgS3tFY/sP/wEXR2q0iirfO9OEg==
+"@storybook/addon-actions@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.1.14.tgz#20a173d781d99368a1af769ed75551a3784f3135"
+  integrity sha512-mXvrL8B34Rtq1WPxbQ1eUip8spqQP43HWGRH0ZmCO3Iwwcmxd6250LY3q+95QqJYsli0XJoOnS97VOLXABpaPg==
   dependencies:
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/client-api" "6.1.10"
-    "@storybook/components" "6.1.10"
-    "@storybook/core-events" "6.1.10"
-    "@storybook/theming" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/client-api" "6.1.14"
+    "@storybook/components" "6.1.14"
+    "@storybook/core-events" "6.1.14"
+    "@storybook/theming" "6.1.14"
     core-js "^3.0.1"
     fast-deep-equal "^3.1.1"
     global "^4.3.2"
@@ -2985,17 +3072,17 @@
     util-deprecate "^1.0.2"
     uuid "^8.0.0"
 
-"@storybook/addon-backgrounds@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-6.1.10.tgz#eba6faf23f7cb060664d05245b1b886b98edc604"
-  integrity sha512-RoFq/ijJLfJg7TwGfDLReqyBdmKOTfz+QVsYSPPDZdohL4k5mQhX05UKFzxAsXdYAtQdQcsIFOU6OioqAJPrsQ==
+"@storybook/addon-backgrounds@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-6.1.14.tgz#5c65c16e12558a3bc071fdf916305fa0531bb2f1"
+  integrity sha512-ckRB1//D75XALLUaGZxHnKtgJMLi3A59M1AYDnpx6MwK2cjJLFwadCiyri9tDl2mY3aOYHD4C52MrHzxT9u5fQ==
   dependencies:
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/components" "6.1.10"
-    "@storybook/core-events" "6.1.10"
-    "@storybook/theming" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/components" "6.1.14"
+    "@storybook/core-events" "6.1.14"
+    "@storybook/theming" "6.1.14"
     core-js "^3.0.1"
     global "^4.3.2"
     memoizerific "^1.11.3"
@@ -3003,24 +3090,24 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-controls@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.1.10.tgz#c5fa6ea6266f43a952abe18754ae5de3135eab9e"
-  integrity sha512-m/EThT3xc1XNzZVS24Ic7+lBfWxD83M89R8BzGnqJzvxtdhRV/snSDMQlauX8Rwwdlh7A1MfZUCvERllH19M+g==
+"@storybook/addon-controls@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.1.14.tgz#3f4f9e60763facecb654867881533785454ea16d"
+  integrity sha512-4KzTD5J9pUHFe2kBE1gfDw0wjiSsXjMqX82L+l0vzt1GGqQR1Bkaqodg4eGgCM2SU50ysVWvgC3N5BYEiFeZkw==
   dependencies:
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/client-api" "6.1.10"
-    "@storybook/components" "6.1.10"
-    "@storybook/node-logger" "6.1.10"
-    "@storybook/theming" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/client-api" "6.1.14"
+    "@storybook/components" "6.1.14"
+    "@storybook/node-logger" "6.1.14"
+    "@storybook/theming" "6.1.14"
     core-js "^3.0.1"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.1.10.tgz#a118d1c9c0ff3158e95de59b752e367aadd6880b"
-  integrity sha512-AN8F/ZYiHHfylCy7Ztlgist3Na4x6ojcijd83h0INgLDB1T3nZQOALd8801KmKgtPIF2843lYIr4fB11llLFPw==
+"@storybook/addon-docs@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.1.14.tgz#fc1feac0e7e8b9c46efcd0b9c1f8ba2d306a9b3b"
+  integrity sha512-Skj9crqaEEISghobjtu3EKbSTwGVK2e0gTu94WqPL3GOugvGgk7b1VrCgf5fXKcdwbtZktm48CtdmeP5R5U9NQ==
   dependencies:
     "@babel/core" "^7.12.1"
     "@babel/generator" "^7.12.1"
@@ -3031,18 +3118,18 @@
     "@mdx-js/loader" "^1.6.19"
     "@mdx-js/mdx" "^1.6.19"
     "@mdx-js/react" "^1.6.19"
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/client-api" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/components" "6.1.10"
-    "@storybook/core" "6.1.10"
-    "@storybook/core-events" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/client-api" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/components" "6.1.14"
+    "@storybook/core" "6.1.14"
+    "@storybook/core-events" "6.1.14"
     "@storybook/csf" "0.0.1"
-    "@storybook/node-logger" "6.1.10"
-    "@storybook/postinstall" "6.1.10"
-    "@storybook/source-loader" "6.1.10"
-    "@storybook/theming" "6.1.10"
+    "@storybook/node-logger" "6.1.14"
+    "@storybook/postinstall" "6.1.14"
+    "@storybook/source-loader" "6.1.14"
+    "@storybook/theming" "6.1.14"
     acorn "^7.1.0"
     acorn-jsx "^5.1.0"
     acorn-walk "^7.0.0"
@@ -3063,80 +3150,80 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-essentials@^6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-6.1.10.tgz#363796c8d4dbb3c2aa1357bf5d0fe160961ca7c1"
-  integrity sha512-7Jz4JDOJtbXPXbg1WX/4iH9/cirxV9NxIqfY/fItkShmnY/FxiUF+ItRygXUCV22DgL3tKe8spzwGfggTz+mDw==
+"@storybook/addon-essentials@^6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-6.1.14.tgz#5dbd90417fe0bebded547cc9131072acef4aef84"
+  integrity sha512-JcBq6wqO5C0JM/8GPBTiqBqbh5yYZzJJyRAwH8uZ44aaX94kTIuCF3wgNRCfA0Ed2ub+aMjd+ZFjpRD7dhkRSA==
   dependencies:
-    "@storybook/addon-actions" "6.1.10"
-    "@storybook/addon-backgrounds" "6.1.10"
-    "@storybook/addon-controls" "6.1.10"
-    "@storybook/addon-docs" "6.1.10"
-    "@storybook/addon-toolbars" "6.1.10"
-    "@storybook/addon-viewport" "6.1.10"
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/node-logger" "6.1.10"
+    "@storybook/addon-actions" "6.1.14"
+    "@storybook/addon-backgrounds" "6.1.14"
+    "@storybook/addon-controls" "6.1.14"
+    "@storybook/addon-docs" "6.1.14"
+    "@storybook/addon-toolbars" "6.1.14"
+    "@storybook/addon-viewport" "6.1.14"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/node-logger" "6.1.14"
     core-js "^3.0.1"
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-toolbars@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-6.1.10.tgz#8ed5b62a320bf442d37171ae6a6613d800831c40"
-  integrity sha512-8oSbhpB7drHLNtHgG1IN/G3puODFZCGQvbLzLhrDXJe33+FtsmWLqERgbG4FsYk9ZR1XM+oLn7HL/A85HwwWHg==
+"@storybook/addon-toolbars@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-6.1.14.tgz#d28c9f8e980fcb542645c833a20183b4e0d07425"
+  integrity sha512-vYmMsfNwvAKwbD65tgNwKUUOebqKnzyc359r+5tgOu5U2HegXvPrgLTMbke4KkkSJTj5EAHE6SHusdjEzq8/dA==
   dependencies:
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/client-api" "6.1.10"
-    "@storybook/components" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/client-api" "6.1.14"
+    "@storybook/components" "6.1.14"
     core-js "^3.0.1"
 
-"@storybook/addon-viewport@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-6.1.10.tgz#f253516d61945904cc18149d8efa8937e4cc06c7"
-  integrity sha512-KIVq4sOBP9gTGvbvbCJn3JW1O5V6NGLTGD+NaZhEbArSoa5rxNFzmqGSRbhOKmf/SC49/t4GUv57xv+bYZQxZg==
+"@storybook/addon-viewport@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-6.1.14.tgz#db92b2c1fb5bbaf8240e26f433e6c6d9829de33a"
+  integrity sha512-5u9Atyfmz8fNHo0CCp1e5bHKmdHIchhzel9gIzSYnwCDDILaB8iPmQwxdb9v2nerUCHGIH9CNJbTYpECqpBK2A==
   dependencies:
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/components" "6.1.10"
-    "@storybook/core-events" "6.1.10"
-    "@storybook/theming" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/components" "6.1.14"
+    "@storybook/core-events" "6.1.14"
+    "@storybook/theming" "6.1.14"
     core-js "^3.0.1"
     global "^4.3.2"
     memoizerific "^1.11.3"
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@6.1.10", "@storybook/addons@^6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.1.10.tgz#3219134bb57d26b97c1d36c0eca3649a7f952d82"
-  integrity sha512-hTyqBDujXnOsk63EiHDPtHqXl9ZJKHf2AGjnvYVe8hjHyYPFlHM5mb0LGoZ2QEe3hd99voe3oEk33phZ+XSbZA==
+"@storybook/addons@6.1.14", "@storybook/addons@^6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.1.14.tgz#2b81304bbe696923df95cdcf85cfc592d10f4065"
+  integrity sha512-HlpmV7aejp/MeW8bo/WKME3i71gi0men9qcwoovjDjnSF6jXoNLT336a5udKXdHqYSZgzdyURlgLtilCWkWaJQ==
   dependencies:
-    "@storybook/api" "6.1.10"
-    "@storybook/channels" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/core-events" "6.1.10"
-    "@storybook/router" "6.1.10"
-    "@storybook/theming" "6.1.10"
+    "@storybook/api" "6.1.14"
+    "@storybook/channels" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/core-events" "6.1.14"
+    "@storybook/router" "6.1.14"
+    "@storybook/theming" "6.1.14"
     core-js "^3.0.1"
     global "^4.3.2"
     regenerator-runtime "^0.13.7"
 
-"@storybook/api@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.1.10.tgz#7261c43ace576201945bbbc8289b7e0adc174a57"
-  integrity sha512-SjAhQ261KagU29jraNZo0hCn8XxuEl8i6WWwJiQyPzk1Grw3Rag/fl2FpQnNHj+3O87PfRrJLSVnGQZcfiW5zw==
+"@storybook/api@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.1.14.tgz#20035dd336aba1c5a0f8c83c8c14a2edaf4db891"
+  integrity sha512-gWcC/xEW8HL5DsocLujHBUdoNsl4YW1Zx1Y4SBbLCyrhj8v4JudJpylwJpOUBDe/GESXq1zqvNKvUPtI8DQNyw==
   dependencies:
     "@reach/router" "^1.3.3"
-    "@storybook/channels" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/core-events" "6.1.10"
+    "@storybook/channels" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/core-events" "6.1.14"
     "@storybook/csf" "0.0.1"
-    "@storybook/router" "6.1.10"
+    "@storybook/router" "6.1.14"
     "@storybook/semver" "^7.3.2"
-    "@storybook/theming" "6.1.10"
+    "@storybook/theming" "6.1.14"
     "@types/reach__router" "^1.3.5"
     core-js "^3.0.1"
     fast-deep-equal "^3.1.1"
@@ -3149,38 +3236,38 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/channel-postmessage@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.1.10.tgz#570f70c6999ae8cb8957b9990e1a402ff11f74da"
-  integrity sha512-33Xs0gDxUNGxz03YlBjSyD9wFGRSIl+E/x1EqfErsm9CRb7PyHaeEuJ9wcYrPtMJnzAvndyQEEGfnzgXk5qbQg==
+"@storybook/channel-postmessage@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.1.14.tgz#41f3115895010dad9fb30f4ac381e4f904b1e50c"
+  integrity sha512-If83dXXW9mKIRuvuWhWa/zkEw/F0FDgikp33x8436J3rWCh3recp27kffFRrKG0YDMpFSk/Ci5G47E9zn9SCjw==
   dependencies:
-    "@storybook/channels" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/core-events" "6.1.10"
+    "@storybook/channels" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/core-events" "6.1.14"
     core-js "^3.0.1"
     global "^4.3.2"
     qs "^6.6.0"
     telejson "^5.0.2"
 
-"@storybook/channels@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.1.10.tgz#31da5d78052532171846e3e0465832111b65f315"
-  integrity sha512-6WyK0OmIy0Gr58JvsmfupquTNsISkGSQX5zgUN2vMMB/rLl7HbddU7/yE/tv/F9fVJag3pXSo3pqlgtdfxXoyw==
+"@storybook/channels@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.1.14.tgz#c479190ebb853a603f3ed90fc470534a02eb46eb"
+  integrity sha512-vP19IB2FXj8SiFbQ9ETljEBienL+KRMLgMzz3Ta3nZj/OfjJJbIuj42ZfexQGV4mS0Bo+OW+qT7VMIY6fulnFw==
   dependencies:
     core-js "^3.0.1"
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-api@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.1.10.tgz#de243900d71c34b93a0714acd268ecba199d255a"
-  integrity sha512-qnKTL0EDEoFri7XwcmuZtcRB+AY8N72F4QFgAiLRBYVOQeEhbdZOpRJBmEA4PKjoDAU+EuIueb90hW91ZgtoBw==
+"@storybook/client-api@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.1.14.tgz#6daf56743cc72e13f05fff3d2ac554897cc9f9fd"
+  integrity sha512-pIDSlS48bhJdtgNg7sXV1NmLJtB0ebRHJI9htIiqtL7EGQenb4+Bbwflhj1j51OEkuM+bQsAAZxq5deiUQEGVw==
   dependencies:
-    "@storybook/addons" "6.1.10"
-    "@storybook/channel-postmessage" "6.1.10"
-    "@storybook/channels" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/core-events" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/channel-postmessage" "6.1.14"
+    "@storybook/channels" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/core-events" "6.1.14"
     "@storybook/csf" "0.0.1"
     "@types/qs" "^6.9.0"
     "@types/webpack-env" "^1.15.3"
@@ -3195,23 +3282,23 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-logger@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.10.tgz#491d960387ab336408f596c22f171c19247a1236"
-  integrity sha512-06EnESLaNCeHSzsZEEMiy9QtyucTy2BvQ2Z0yPnZLuXTXZNgI6aOtftpehwKSYXdudaIvLkb6xfNvix0BBgHhw==
+"@storybook/client-logger@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.14.tgz#216b9c1332ffa3a3473dad837780a3b14f686bae"
+  integrity sha512-NSO8nVsp6o0eoQ1Drlu66KXpl6DPuq02Kj8AhttGzvqSYB50SV4CV+wceBcg77tIVu5QmQ+71hAEVXhx7sjRHA==
   dependencies:
     core-js "^3.0.1"
     global "^4.3.2"
 
-"@storybook/components@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.1.10.tgz#1c82504ebdb24c317168745600fb5264f572694e"
-  integrity sha512-n3+tlSFt+hapNxkASpAIEhyXDR7xmE/x+LW4xxuYfRRxvOy0zAgcrgY8BkDmxWzGH3M/Ev5uVVVdxaRIw7i2SA==
+"@storybook/components@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.1.14.tgz#4ea47edfa0a3e4a26882aa5a1eb90c1ec86e6f71"
+  integrity sha512-Nxsp/9o1tqfY8s6RBWNHyM03A5D9k56Kr/4VNa++CbDrz1+TIxpYlDgS4sllUlXyvICLfk3sUtg3KS5CPl2iZA==
   dependencies:
-    "@popperjs/core" "^2.4.4"
-    "@storybook/client-logger" "6.1.10"
+    "@popperjs/core" "^2.5.4"
+    "@storybook/client-logger" "6.1.14"
     "@storybook/csf" "0.0.1"
-    "@storybook/theming" "6.1.10"
+    "@storybook/theming" "6.1.14"
     "@types/overlayscrollbars" "^1.9.0"
     "@types/react-color" "^3.0.1"
     "@types/react-syntax-highlighter" "11.0.4"
@@ -3224,22 +3311,22 @@
     overlayscrollbars "^1.10.2"
     polished "^3.4.4"
     react-color "^2.17.0"
-    react-popper-tooltip "^3.1.0"
+    react-popper-tooltip "^3.1.1"
     react-syntax-highlighter "^13.5.0"
     react-textarea-autosize "^8.1.1"
     ts-dedent "^2.0.0"
 
-"@storybook/core-events@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.10.tgz#e7eff165753c50c2f92adb8cd1576d3799d94e4c"
-  integrity sha512-Xv56iXXSf53xiBDW0XEKypfw+1HZw7BN38AISQdbEX5+0y+VLHdWe6vdXIeoXz6ja0lP0Dnrjn4g8usenJzgmA==
+"@storybook/core-events@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.14.tgz#a3165e32cefd6be7326bbad4b8140653bdfa0426"
+  integrity sha512-tpM3VDvzqgRY7S17CRglgt1625rxNoyEwrLQiNcZkUPyO0rpaacPqVEbPCtcTmUeboI1bLdnSQIjT9B0/Y2Pww==
   dependencies:
     core-js "^3.0.1"
 
-"@storybook/core@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-6.1.10.tgz#c86819dab3710fa52c3744aa4a8050eec6833ffe"
-  integrity sha512-AIsb35tmy9Y5LKsn9dJpHoVHn3pCbR+fOVNq75Sdm3hc5NfRAeNIM/qrCnp8BRRzAFIYDPU59kTFX3LHxIlIvg==
+"@storybook/core@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-6.1.14.tgz#17e724a5b94d6e1bb557e213b8176660d2d14762"
+  integrity sha512-lHKZmfLAo2VGtF/yrZkkWMYgmFRNKbzIDxYJGp8USyUQyTfEpz2qqJlBdoD6rxr1hFPM2954tIKwh8iPhT2PFQ==
   dependencies:
     "@babel/core" "^7.12.3"
     "@babel/plugin-proposal-class-properties" "^7.12.1"
@@ -3263,20 +3350,20 @@
     "@babel/preset-react" "^7.12.1"
     "@babel/preset-typescript" "^7.12.1"
     "@babel/register" "^7.12.1"
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/channel-postmessage" "6.1.10"
-    "@storybook/channels" "6.1.10"
-    "@storybook/client-api" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/components" "6.1.10"
-    "@storybook/core-events" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/channel-postmessage" "6.1.14"
+    "@storybook/channels" "6.1.14"
+    "@storybook/client-api" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/components" "6.1.14"
+    "@storybook/core-events" "6.1.14"
     "@storybook/csf" "0.0.1"
-    "@storybook/node-logger" "6.1.10"
-    "@storybook/router" "6.1.10"
+    "@storybook/node-logger" "6.1.14"
+    "@storybook/router" "6.1.14"
     "@storybook/semver" "^7.3.2"
-    "@storybook/theming" "6.1.10"
-    "@storybook/ui" "6.1.10"
+    "@storybook/theming" "6.1.14"
+    "@storybook/ui" "6.1.14"
     "@types/glob-base" "^0.3.0"
     "@types/micromatch" "^4.0.1"
     "@types/node-fetch" "^2.5.4"
@@ -3350,10 +3437,10 @@
   dependencies:
     lodash "^4.17.15"
 
-"@storybook/node-logger@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.1.10.tgz#0d69f30cf4c798919d2e467fad11d95273265ec7"
-  integrity sha512-ABmkDbqsEgP+Szzs0TSaAeaudCtA25Pbd9n5bhaMQBqka86VV0Engtm5FHtYBE58XzWjD8L3AoBkPOt0mtRDVg==
+"@storybook/node-logger@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.1.14.tgz#e5294f986e3ec5c67b2738895b9d16c9a2b667fa"
+  integrity sha512-3jrw7coAwFXZu4qK1vm54bCPhNRvxjG+7jISbhhocDoNIv0nLWL3+tJyrC5/k/XHQiUlLkhEzpMaASADmkttNw==
   dependencies:
     "@types/npmlog" "^4.1.2"
     chalk "^4.0.0"
@@ -3373,10 +3460,10 @@
     pretty-hrtime "^1.0.3"
     regenerator-runtime "^0.13.3"
 
-"@storybook/postinstall@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-6.1.10.tgz#bd5fb91c704dbb2b6e3a65e1372781732aae1ed2"
-  integrity sha512-EhlDF5rc2aA2szkjaFrd3pvwa1zJkJLF1sYwJMlzaw6/5RoaNSu4ecccMJfTHJJdhaMjcchFK/8NImF0XjrP5w==
+"@storybook/postinstall@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-6.1.14.tgz#ec931739d566bbd3b15b742c32be82701e4910b9"
+  integrity sha512-A2ytqaoNjZoxmK3kZ2FxeQki6gZugGdPnEMbs8q+EJq7IN3UEbxisdGj6vxKXf/rlyZ1G1t2jSQ4xmkBF8+fZg==
   dependencies:
     core-js "^3.0.1"
 
@@ -3391,17 +3478,17 @@
     babel-preset-typescript-vue "^1.0.3"
     fork-ts-checker-webpack-plugin "^4.1.0"
 
-"@storybook/react@^6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-6.1.10.tgz#bd1883e4c82370dd7180e80f7e006ea1dda3a91d"
-  integrity sha512-m6A2JkybvSZEh/DQe7az7qRxvbM+yBh3z5ziJ1CLX6CkLtjUkQ+D5666b+/CUXqp297e/xDVFMNt3rSuqNHdpA==
+"@storybook/react@^6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-6.1.14.tgz#436e9b90096b1d7c83f7f073b5baf47212b2e425"
+  integrity sha512-M99wHjc/5z+Wz1FdFaScVs6dyAi/6PdcIx5Fyip6Qd8aKwm1XyYoOMql5Vu3Cf560feDYCKS4phzyEZ7EJy+EQ==
   dependencies:
     "@babel/preset-flow" "^7.12.1"
     "@babel/preset-react" "^7.12.1"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.4.2"
-    "@storybook/addons" "6.1.10"
-    "@storybook/core" "6.1.10"
-    "@storybook/node-logger" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/core" "6.1.14"
+    "@storybook/node-logger" "6.1.14"
     "@storybook/semver" "^7.3.2"
     "@types/webpack-env" "^1.15.3"
     babel-plugin-add-react-displayname "^0.0.5"
@@ -3418,10 +3505,10 @@
     ts-dedent "^2.0.0"
     webpack "^4.44.2"
 
-"@storybook/router@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.1.10.tgz#c6d6fe8bc0e767bdbbd95750799de12f56603ff1"
-  integrity sha512-q9rQzkwz0Sz6lIfiEP4uydmZ3+ERSFhv/M8BZvZTiTKH3IXgYVbjoCFPRjtR3qyvIw6gHXh3ipy0JssUig/yYg==
+"@storybook/router@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.1.14.tgz#f6aef8c9dabf19bf06dddd80907e66369261fdde"
+  integrity sha512-rMaUCYzgfVLwFWo3A1Q/weSv8FBqCLmHY+3+t6ao7OV6NYjR0XgLKRzHrXq1uYdbMxWeIKhN2tIt/LR43bmDjQ==
   dependencies:
     "@reach/router" "^1.3.3"
     "@types/reach__router" "^1.3.5"
@@ -3438,13 +3525,13 @@
     core-js "^3.6.5"
     find-up "^4.1.0"
 
-"@storybook/source-loader@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-6.1.10.tgz#984bfe77dfecb989dbba2c0bf0a40d0b90013489"
-  integrity sha512-ovQa5hoM/AdIblSlPXa5RokEy3DIq/H+JZAOA8zIN6gn4ZrdROEhbztK0MB1jcMsVARrORRVSEg8us/AiMTfwQ==
+"@storybook/source-loader@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-6.1.14.tgz#507ff52cc6627e4d996020de05bf023004230953"
+  integrity sha512-JY3hJGTJSNmohmDDE3BLE3vPW1rSAIRToq0vpo9ZhFTFUWHm3RlhcS8+5z8Mvn9+TLDuf5WnSib5lfGmCtLmJQ==
   dependencies:
-    "@storybook/addons" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
     "@storybook/csf" "0.0.1"
     core-js "^3.0.1"
     estraverse "^4.2.0"
@@ -3455,15 +3542,15 @@
     regenerator-runtime "^0.13.7"
     source-map "^0.7.3"
 
-"@storybook/theming@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.1.10.tgz#f41f23c9ac8602eac48a62c69ad24137381d2247"
-  integrity sha512-6XDfDBQUxS2WzacPWa4qDc6z1HlbkIveFxhsXPn1O59CclnTJHqPI6bltcC3EKRSAYhgLBJmGbft4CedK6Ypzg==
+"@storybook/theming@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.1.14.tgz#fecb66cab22d3b3218b4a98a9c210eb8a7be91e8"
+  integrity sha512-S+t30y4FqBTXWoVr+dtxVJ/ywiQGHBclBd9aUunbdCV4mMFra5InNo2CWn+RJlNEauLZ93gRIEzSFchIbzLk1A==
   dependencies:
     "@emotion/core" "^10.1.1"
     "@emotion/is-prop-valid" "^0.8.6"
     "@emotion/styled" "^10.0.23"
-    "@storybook/client-logger" "6.1.10"
+    "@storybook/client-logger" "6.1.14"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"
@@ -3473,21 +3560,21 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/ui@6.1.10":
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-6.1.10.tgz#7967765decb2d5816c61633712eb3f55d57249df"
-  integrity sha512-py3wkG3OxOrYsPG4Kq1c3JP88fZ28/k7dxpx85bH+9N0wzMbxAlEvbA9E01Phv64aR18yPiHjAgJNIw5DQw+gg==
+"@storybook/ui@6.1.14":
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-6.1.14.tgz#766d696480ee6f6a5a0454ccb2f101c38a0eb9d2"
+  integrity sha512-DTW2TM05jTMKxh8LzUGk3g5a528PgJxrtgODFU6zzwSg2+LwdmSDtd1HAxopt2vpfTyQyX+6WN2H+lMNwfQTAQ==
   dependencies:
     "@emotion/core" "^10.1.1"
-    "@storybook/addons" "6.1.10"
-    "@storybook/api" "6.1.10"
-    "@storybook/channels" "6.1.10"
-    "@storybook/client-logger" "6.1.10"
-    "@storybook/components" "6.1.10"
-    "@storybook/core-events" "6.1.10"
-    "@storybook/router" "6.1.10"
+    "@storybook/addons" "6.1.14"
+    "@storybook/api" "6.1.14"
+    "@storybook/channels" "6.1.14"
+    "@storybook/client-logger" "6.1.14"
+    "@storybook/components" "6.1.14"
+    "@storybook/core-events" "6.1.14"
+    "@storybook/router" "6.1.14"
     "@storybook/semver" "^7.3.2"
-    "@storybook/theming" "6.1.10"
+    "@storybook/theming" "6.1.14"
     "@types/markdown-to-jsx" "^6.11.0"
     copy-to-clipboard "^3.0.8"
     core-js "^3.0.1"
@@ -6121,7 +6208,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.1, classnames@^2.2.5:
+classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -7339,6 +7426,13 @@ dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
+
+dom7@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/dom7/-/dom7-3.0.0.tgz#b861ce5d67a6becd7aaa3ad02942ff14b1240331"
+  integrity sha512-oNlcUdHsC4zb7Msx7JN3K0Nro1dzJ48knvBOnDPKJ2GV9wl1i5vydJZUSyOfrkKFDZEud/jBsTk92S/VGSAe/g==
+  dependencies:
+    ssr-window "^3.0.0-alpha.1"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -14017,13 +14111,6 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
-raf@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
-
 ramda@0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
@@ -14071,36 +14158,6 @@ raw-loader@^4.0.1:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
-
-rc-resize-observer@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/rc-resize-observer/-/rc-resize-observer-0.2.3.tgz#8268284d1766d163240b1682661ae7b59bc4523d"
-  integrity sha512-dEPCGX15eRRnu+TNBIGyEghpzE24fTDW8pHdJPJS/kCR3lafFqBLqKzBgZW6pMUuM70/ZDyFQ0Kynx9kWsXRNw==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "^2.2.1"
-    rc-util "^5.0.0"
-    resize-observer-polyfill "^1.5.1"
-
-rc-table@^7.8.4:
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-7.8.4.tgz#493e6e8ccd9f078a073f0f7cf46bbb02c55f74d7"
-  integrity sha512-+8JPFD4oGy/4/VdXsPE/12oEkopiZoIi4cS6DJGzjf2CjhrM7KevUOjrs0MhFlXZp/Pnb8qSKoVdVHN1JYtL7Q==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "^2.2.5"
-    raf "^3.4.1"
-    rc-resize-observer "^0.2.0"
-    rc-util "^5.0.0"
-    shallowequal "^1.1.0"
-
-rc-util@^5.0.0:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.0.5.tgz#d29d626edc931fbf8b45b4aa48fb9e44ce2300bd"
-  integrity sha512-zLIdNm6qz+hQbB5T1fmzHFFgPuRl3uB2eS2iLR/mewUWvgC3l7NzRYRVlHoCEEFVUkKEEsHuJXG1J52FInl5lA==
-  dependencies:
-    react-is "^16.12.0"
-    shallowequal "^1.1.0"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
   version "1.2.8"
@@ -14258,7 +14315,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-popper-tooltip@^3.1.0:
+react-popper-tooltip@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz#329569eb7b287008f04fcbddb6370452ad3f9eac"
   integrity sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==
@@ -14839,11 +14896,6 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-resize-observer-polyfill@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
-  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -15681,6 +15733,11 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+ssr-window@^3.0.0, ssr-window@^3.0.0-alpha.1:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-3.0.0.tgz#fd5b82801638943e0cc704c4691801435af7ac37"
+  integrity sha512-q+8UfWDg9Itrg0yWK7oe5p/XRCJpJF9OBtXfOPgSJl+u3Xd5KI328RUEvUqSMVM9CiQUEf1QdBzJMkYGErj9QA==
+
 ssri@^6.0.0, ssri@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
@@ -16080,6 +16137,15 @@ svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+swiper@^6.4.5:
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.4.5.tgz#2aa9e7f59ed0578c411626bf24cdb5942609618e"
+  integrity sha512-MJIY0aXF6UKgUM+/tgwtOxI21fwRiT6QX2decd6m2L9OGA7jLBks8E0CuUuRqpQfmTInQrBPnBy8dqgOtr2O0w==
+  dependencies:
+    dom7 "^3.0.0"
+    ssr-window "^3.0.0"
+    tslib "^2.0.0"
 
 symbol-observable@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
Issue [#792](https://github.com/binance-chain/ui-project-management/issues/792).

Note: I am aware I used `!important` (bad 😢 ) but it's the only way to override the `swiper` library's generated inline styles.

Medium+ screens:
<img width="765" alt="image" src="https://user-images.githubusercontent.com/15721063/105336552-4331d880-5c3e-11eb-9195-3938982a0428.png">

Small screens:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/15721063/105336607-5644a880-5c3e-11eb-828f-acac0d380dab.png">
