### PR TITLE
feat(Tooltip): Add optional `bare` prop (#796)

### DIFF
--- a/src/components/Tooltip/component.stories.tsx
+++ b/src/components/Tooltip/component.stories.tsx
@@ -6,8 +6,9 @@ import { Story } from '@storybook/react/types-6-0';
 import { decorators } from '../../modules/decorators';
 import { Sections } from '../../modules/sections';
 import { HoneycombThemeProvider } from '../../modules/themes';
-import { Space } from '../Space';
 import { Button } from '../Button';
+import { Space } from '../Space';
+import { Text } from '../Text';
 
 import { RADII, SIZES, VARIANTS } from './styled';
 
@@ -61,6 +62,15 @@ const PlacementContainer = styled.div`
 export const Variants = () => {
   return (
     <Container>
+      <h3>bare</h3>
+      <Label>default=false</Label>
+      <Row>
+        <Tooltip visible content={<Text size="small">bare</Text>} bare>
+          <div />
+        </Tooltip>
+      </Row>
+      <Space size="increased" />
+
       <h3>padding</h3>
       <Label>default="small"</Label>
       <Row>

--- a/src/components/Tooltip/component.tsx
+++ b/src/components/Tooltip/component.tsx
@@ -32,16 +32,19 @@ export type Props = Pick<React.HTMLProps<HTMLElement>, 'children' | 'style'> &
     radius?: Radius;
     shape?: Shape;
     variant?: Variant;
+    bare?: boolean;
   };
 
 export const Component = ({
   className,
   children,
+  content: contentProp,
   padding = 'small',
   radius = 'reduced',
   shape = 'fill',
   variant = 'normal',
   trigger: triggerProp = 'mouseenter',
+  bare = false,
   'data-testid': testId,
   ...otherProps
 }: Props) => {
@@ -54,28 +57,36 @@ export const Component = ({
     return triggerProp.join(' ');
   }, [triggerProp, otherProps.visible]);
 
+  const content = useMemo(() => {
+    if (bare) {
+      return <div data-testid={buildTestId('content')}>{contentProp}</div>;
+    }
+
+    return (
+      <Content
+        padding={padding}
+        $radius={radius}
+        variant={variant}
+        data-testid={buildTestId('content')}
+      >
+        {contentProp}
+      </Content>
+    );
+  }, [contentProp, bare, padding, radius, variant, buildTestId]);
+
   return (
     <>
       <Styles variant={variant} />
       <Tippy
         {...otherProps}
+        className={className || ''} // Tippy throws error if className is undefined.
         trigger={trigger}
         theme={`bc-honeycomb-bare-${theme.honeycomb.id}-${variant}`}
         arrow={otherProps.arrow}
         animation="shift-away"
         placement={otherProps.placement ?? 'bottom-start'}
         zIndex={theme.honeycomb.zIndexes.tooltips}
-        content={
-          <Content
-            padding={padding}
-            $radius={radius}
-            variant={variant}
-            className={className}
-            data-testid={buildTestId('content')}
-          >
-            {otherProps.content}
-          </Content>
-        }
+        content={content}
       >
         <Target $shape={shape} data-testid={buildTestId('target')}>
           {children}


### PR DESCRIPTION
Issue [#796](https://github.com/binance-chain/ui-project-management/issues/796).

Example added to story.

<img width="442" alt="image" src="https://user-images.githubusercontent.com/15721063/107643506-1cb20b00-6cdb-11eb-9cbe-047d6834b788.png">
