### PR TITLE
fix(Select, Dropdown): Fix spacing, add HTML attributes to `DefaultTarget`

### DIFF
--- a/src/components/Dropdown/DefaultTarget/Icon/styled.tsx
+++ b/src/components/Dropdown/DefaultTarget/Icon/styled.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../../../Icon';
 
 const icon = css`
   font-size: ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
+  margin-left: ${({ theme }) => em(theme.honeycomb.size.micro, theme.honeycomb.size.small)};
   flex-shrink: 0;
 `;
 

--- a/src/components/Dropdown/DefaultTarget/component.tsx
+++ b/src/components/Dropdown/DefaultTarget/component.tsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 
 import { Context } from '../context';
-import { Space } from '../../Space';
 import { Styleless } from '../../Styleless';
 
 import { Icon } from './Icon';
@@ -29,12 +28,7 @@ export const Component = ({
       isShowing={isShowing}
     >
       {otherProps.children}
-      {arrow && (
-        <>
-          <Space size="micro" base="reduced" />
-          <Icon open={isShowing} />
-        </>
-      )}
+      {arrow && <Icon open={isShowing} />}
     </StyledDefaultTarget>
   );
 };

--- a/src/components/Select/DefaultTarget/component.tsx
+++ b/src/components/Select/DefaultTarget/component.tsx
@@ -9,10 +9,8 @@ import { useCurrentVariant } from '../useCurrentVariant';
 
 import { StyledListItem } from './styled';
 
-export type Props = Pick<
-  React.ComponentPropsWithoutRef<typeof ListItem>,
-  'children' | 'left' | 'onClick'
->;
+export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as'> &
+  Pick<React.ComponentPropsWithoutRef<typeof ListItem>, 'children' | 'left' | 'onClick'>;
 
 export const Component = ({ children, onClick, ...otherProps }: Props) => {
   const { variant = 'responsive', isShowing, testId: parentTestId } = useContext(Context);


### PR DESCRIPTION
Use CSS instead of `<Space />`, which adds another element to the DOM. Add HTML attributes back to `<Select.DefaultTarget />` which was removed in PR #209 for adding attributes like `type` (in the browser extension).