### PR TITLE
feat: Consistent test IDs in components with helpers

### DIFF
--- a/cypress/integration/Dropdown.ts
+++ b/cypress/integration/Dropdown.ts
@@ -6,7 +6,7 @@ describe('Dropdown', () => {
     cy.get('[data-testid="light.dropdown.target"]').click();
     cy.get('[data-testid="light.dropdown.content"]').should('exist');
 
-    cy.get('[data-testid="light.dropdown.content.item1"]').should('exist');
+    cy.get('[data-testid="light.dropdown.item1"]').should('exist');
 
     cy.percySnapshot('Dropdown while open');
   });
@@ -28,7 +28,7 @@ describe('Dropdown', () => {
 
     cy.get('[data-testid="light.dropdown.target"]').click();
 
-    cy.get('[data-testid="light.dropdown.content.item1"]')
+    cy.get('[data-testid="light.dropdown.item1"]')
       .click()
       .then(() => {
         expect(stub.getCall(0)).to.be.calledWith('item1');
@@ -43,12 +43,12 @@ describe('Dropdown', () => {
     cy.get('[data-testid="light.dropdown.target"]').click();
 
     new Array(5).fill(null).forEach((_, index) => {
-      cy.get(`[data-testid="light.dropdown.content.${index}"]`).should('be.visible');
-      cy.get(`[data-testid="light.dropdown.content.${index}.tick"]`).should('not.exist');
+      cy.get(`[data-testid="light.dropdown.${index}"]`).should('be.visible');
+      cy.get(`[data-testid="light.dropdown.${index}.tick"]`).should('not.exist');
     });
 
-    cy.get(`[data-testid="light.dropdown.content.0"]`).click();
+    cy.get(`[data-testid="light.dropdown.0"]`).click();
     cy.get('[data-testid="light.dropdown.target"]').click();
-    cy.get(`[data-testid="light.dropdown.content.0.tick"]`).should('be.visible');
+    cy.get(`[data-testid="light.dropdown.0.tick"]`).should('be.visible');
   });
 });

--- a/cypress/integration/Select.ts
+++ b/cypress/integration/Select.ts
@@ -43,7 +43,7 @@ describe('Select', () => {
     cy.get('[data-testid="select.input.native-input"]').should('not.exist');
 
     new Array(5).fill(null).forEach((_, index) => {
-      cy.get(`[data-testid="select.item.${index}"]`).should('exist');
+      cy.get(`[data-testid="select.${index}"]`).should('exist');
     });
   });
 
@@ -55,11 +55,11 @@ describe('Select', () => {
     cy.get('[data-testid="light.select.default-target"]').click();
     cy.tick(10000);
 
-    cy.get('[data-testid="light.select.item.0"]').should('be.visible');
-    cy.get('[data-testid="light.select.item.1"]').should('be.visible');
-    cy.get('[data-testid="light.select.item.2"]').should('be.visible');
+    cy.get('[data-testid="light.select.0"]').should('be.visible');
+    cy.get('[data-testid="light.select.1"]').should('be.visible');
+    cy.get('[data-testid="light.select.2"]').should('be.visible');
 
-    cy.get('[data-testid="light.select.item.0"]').click();
+    cy.get('[data-testid="light.select.0"]').click();
     cy.tick(10000);
 
     cy.get('[data-testid="light.select.content"]').should('not.exist');
@@ -67,9 +67,9 @@ describe('Select', () => {
     cy.get('[data-testid="light.select.default-target"]').click();
     cy.tick(10000);
 
-    cy.get('[data-testid="light.select.item.0.tick"]').should('be.visible');
-    cy.get('[data-testid="light.select.item.1.tick"]').should('not.exist');
-    cy.get('[data-testid="light.select.item.2.tick"]').should('not.exist');
+    cy.get('[data-testid="light.select.0.tick"]').should('be.visible');
+    cy.get('[data-testid="light.select.1.tick"]').should('not.exist');
+    cy.get('[data-testid="light.select.2.tick"]').should('not.exist');
 
     cy.percySnapshot('Select variant="dropdown"');
   });
@@ -82,30 +82,30 @@ describe('Select', () => {
     cy.get('[data-testid="select.default-target"]').click();
     cy.tick(10000);
 
-    cy.get('[data-testid="select.item.0"]').should('be.visible');
-    cy.get('[data-testid="select.item.1"]').should('be.visible');
-    cy.get('[data-testid="select.item.2"]').should('be.visible');
-    cy.get('[data-testid="select.item.photo"]').should('be.visible');
+    cy.get('[data-testid="select.0"]').should('be.visible');
+    cy.get('[data-testid="select.1"]').should('be.visible');
+    cy.get('[data-testid="select.2"]').should('be.visible');
+    cy.get('[data-testid="select.photo"]').should('be.visible');
 
-    cy.get('[data-testid="select.item.0"]').click();
+    cy.get('[data-testid="select.0"]').click();
     cy.tick(10000);
     cy.get('[data-testid="select.default-target"]').click();
     cy.tick(10000);
 
-    cy.get('[data-testid="select.item.0.tick"]').should('be.visible');
-    cy.get('[data-testid="select.item.1.tick"]').should('not.exist');
-    cy.get('[data-testid="select.item.2.tick"]').should('not.exist');
-    cy.get('[data-testid="select.item.photo.tick"]').should('not.exist');
+    cy.get('[data-testid="select.0.tick"]').should('be.visible');
+    cy.get('[data-testid="select.1.tick"]').should('not.exist');
+    cy.get('[data-testid="select.2.tick"]').should('not.exist');
+    cy.get('[data-testid="select.photo.tick"]').should('not.exist');
 
     cy.get('[data-testid="select.input.native-input"]').type('crazy');
 
-    cy.get('[data-testid="select.item.0"]').should('not.exist');
-    cy.get('[data-testid="select.item.1"]').should('not.exist');
-    cy.get('[data-testid="select.item.2"]').should('not.exist');
-    cy.get('[data-testid="select.item.photo"]').should('be.visible');
-    cy.get('[data-testid="select.item.photo.tick"]').should('not.exist');
+    cy.get('[data-testid="select.0"]').should('not.exist');
+    cy.get('[data-testid="select.1"]').should('not.exist');
+    cy.get('[data-testid="select.2"]').should('not.exist');
+    cy.get('[data-testid="select.photo"]').should('be.visible');
+    cy.get('[data-testid="select.photo.tick"]').should('not.exist');
 
-    cy.get('[data-testid="select.item.photo"]').click();
+    cy.get('[data-testid="select.photo"]').click();
     cy.tick(10000);
 
     cy.get('[data-testid="select.modal.box"]').should('not.exist');
@@ -114,7 +114,7 @@ describe('Select', () => {
     cy.tick(10000);
 
     cy.get('[data-testid="select.modal.box"]').should('be.visible');
-    cy.get('[data-testid="select.item.photo.tick"]').should('be.visible');
+    cy.get('[data-testid="select.photo.tick"]').should('be.visible');
 
     cy.percySnapshot('Select variant="modal"');
   });

--- a/cypress/integration/Swiper.ts
+++ b/cypress/integration/Swiper.ts
@@ -8,8 +8,8 @@ describe('Swiper', () => {
     .then((children) => {
       children[index].click();
 
-      cy.get(`[data-testid="${theme}.swiper.item-${index}.label"]`).should('be.visible');
-      cy.get(`[data-testid="${theme}.swiper.item-${index}.label"]`).should('have.text', index + 1);
+      cy.get(`[data-testid="${theme}.swiper.${index}.label"]`).should('be.visible');
+      cy.get(`[data-testid="${theme}.swiper.${index}.label"]`).should('have.text', index + 1);
     });
   };
 

--- a/cypress/integration/Table.ts
+++ b/cypress/integration/Table.ts
@@ -41,13 +41,13 @@ describe('Table', () => {
     cy.get('[data-testid="table.row9.col1.td"]').should('contain.text', '10');
 
     cy.get('[data-testid="dropdown.target"]').click();
-    cy.get('[data-testid="dropdown.content.option-1"]').click();
+    cy.get('[data-testid="dropdown.option-1"]').click();
 
     cy.get('[data-testid="table.pagination.go-to-9-btn"]').click();
     cy.get('[data-testid="table.row9.col1.td"]').should('contain.text', '100');
 
     cy.get('[data-testid="dropdown.target"]').click();
-    cy.get('[data-testid="dropdown.content.option-0"]').click();
+    cy.get('[data-testid="dropdown.option-0"]').click();
 
     cy.get('[data-testid="table.pagination.go-to-1-btn"]').should('exist');
     cy.get('[data-testid="table.row9.col1.td"]').should('contain.text', '10');

--- a/src/components/Dropdown/Item/component.tsx
+++ b/src/components/Dropdown/Item/component.tsx
@@ -11,10 +11,16 @@ export type Props = Omit<React.ComponentPropsWithoutRef<typeof ListItem>, 'showB
     variant?: Variant;
   };
 
-export const Component = ({ variant = 'normal', children, onClick, ...otherProps }: Props) => {
+export const Component = ({
+  variant = 'normal',
+  children,
+  onClick,
+  'data-testid': testId,
+  ...otherProps
+}: Props) => {
   const { testId: parentTestId } = useContext(ContentContext);
   const { buildTestId } = useBuildTestId({
-    id: otherProps['data-testid'] ? parentTestId : undefined,
+    id: testId ? parentTestId : undefined,
   });
   const { onClose } = useContext(Context);
 
@@ -37,7 +43,7 @@ export const Component = ({ variant = 'normal', children, onClick, ...otherProps
       onClick={click}
       showBorder={false}
       variant={variant}
-      data-testid={buildTestId(otherProps['data-testid'])}
+      data-testid={buildTestId(testId)}
     >
       {children}
     </StyledListItem>

--- a/src/components/Dropdown/component.tsx
+++ b/src/components/Dropdown/component.tsx
@@ -42,7 +42,7 @@ export const Component = ({
         interactive={true}
         visible={isShowing}
         content={
-          <ContentContext.Provider value={{ testId: buildTestId('content') }}>
+          <ContentContext.Provider value={{ testId: buildTestId() }}>
             <TooltipContent>{children}</TooltipContent>
           </ContentContext.Provider>
         }

--- a/src/components/PanelControl/Item/component.tsx
+++ b/src/components/PanelControl/Item/component.tsx
@@ -18,8 +18,10 @@ export const Component = ({
   'data-testid': testId,
   ...otherProps
 }: Props) => {
-  const { orientation, shape, variant } = useContext(Context);
-  const { buildTestId } = useBuildTestId({ id: testId });
+  const { orientation, shape, variant, testId: parentTestId } = useContext(Context);
+  const { buildTestId } = useBuildTestId({
+    id: testId ? parentTestId : undefined,
+  });
 
   return (
     <Styled
@@ -29,7 +31,7 @@ export const Component = ({
       $orientation={orientation}
       $shape={shape}
       variant={variant}
-      data-testid={buildTestId()}
+      data-testid={buildTestId(testId)}
       data-testisselected={!!selected}
     />
   );

--- a/src/components/PanelControl/component.stories.tsx
+++ b/src/components/PanelControl/component.stories.tsx
@@ -4,7 +4,6 @@ import { em } from 'polished';
 
 import { decorators } from '../../modules/decorators';
 import { Sections } from '../../modules/sections';
-import { useBuildTestId } from '../../modules/test-ids';
 import { Space } from '../Space';
 import { Text } from '../Text';
 
@@ -25,23 +24,22 @@ const Item = styled(PanelControl.Item)`
 
 export const Horizontal = () => {
   const [selected, setSelected] = useState(0);
-  const { buildTestId } = useBuildTestId({ id: 'panel-control' });
 
   return (
-    <PanelControl orientation="horizontal" variant="solid" data-testid={buildTestId()}>
-      <Item selected={selected === 0} onClick={() => setSelected(0)} data-testid={buildTestId('0')}>
+    <PanelControl orientation="horizontal" variant="solid" data-testid="panel-control">
+      <Item selected={selected === 0} onClick={() => setSelected(0)} data-testid="0">
         <Text size="reduced">Item</Text>
       </Item>
       <Space size="normal" />
-      <Item selected={selected === 1} onClick={() => setSelected(1)} data-testid={buildTestId('1')}>
+      <Item selected={selected === 1} onClick={() => setSelected(1)} data-testid="1">
         <Text size="reduced">Item</Text>
       </Item>
       <Space size="normal" />
-      <Item selected={selected === 2} onClick={() => setSelected(2)} data-testid={buildTestId('2')}>
+      <Item selected={selected === 2} onClick={() => setSelected(2)} data-testid="2">
         <Text size="reduced">Item</Text>
       </Item>
       <Space size="normal" />
-      <Item disabled data-testid={buildTestId('disabled')}>
+      <Item disabled data-testid="disabled">
         <Text size="reduced">Disabled Item</Text>
       </Item>
     </PanelControl>

--- a/src/components/PanelControl/context.tsx
+++ b/src/components/PanelControl/context.tsx
@@ -6,6 +6,7 @@ export const Context = React.createContext<{
   orientation: Orientation;
   shape: Shape;
   variant: Variant;
+  testId?: string;
 }>({
   orientation: 'horizontal',
   shape: 'fill',

--- a/src/components/Select/DefaultTarget/component.tsx
+++ b/src/components/Select/DefaultTarget/component.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react';
 
-import { useBuildTestId } from '../../../modules/test-ids';
+import { Testable, useBuildTestId } from '../../../modules/test-ids';
 import { Icon } from '../../Icon';
 import { DefaultTarget } from '../../internal/DefaultTarget';
 import { ListItem } from '../../ListItem';
@@ -10,14 +10,12 @@ import { useCurrentVariant } from '../useCurrentVariant';
 import { StyledListItem } from './styled';
 
 export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as'> &
-  Pick<React.ComponentPropsWithoutRef<typeof ListItem>, 'children' | 'left' | 'onClick'>;
+  Pick<React.ComponentPropsWithoutRef<typeof ListItem>, 'children' | 'left' | 'onClick'> &
+  Testable;
 
-export const Component = ({ children, onClick, ...otherProps }: Props) => {
-  const { variant = 'responsive', isShowing, testId: parentTestId } = useContext(Context);
-  const { buildTestId: buildTestIdParent } = useBuildTestId({ id: parentTestId });
-  const { buildTestId } = useBuildTestId({
-    id: buildTestIdParent('default-target'),
-  });
+export const Component = ({ children, onClick, 'data-testid': testId, ...otherProps }: Props) => {
+  const { buildTestId } = useBuildTestId({ id: testId });
+  const { variant = 'responsive', isShowing } = useContext(Context);
   const currentVariant = useCurrentVariant({ variant });
 
   const right = useMemo(() => {

--- a/src/components/Select/Option/component.tsx
+++ b/src/components/Select/Option/component.tsx
@@ -12,9 +12,8 @@ export type Props = React.ComponentPropsWithoutRef<typeof ListItem> & {
 
 export const Component = ({ children, onClick, 'data-testid': testId, ...otherProps }: Props) => {
   const { onClose, testId: parentTestId } = useContext(Context);
-  const { buildTestId: buildTestIdParent } = useBuildTestId({ id: parentTestId });
   const { buildTestId } = useBuildTestId({
-    id: buildTestIdParent(testId ? `item.${testId}` : undefined),
+    id: testId ? parentTestId : undefined,
   });
 
   const click = useCallback<NonNullable<Props['onClick']>>(
@@ -31,7 +30,7 @@ export const Component = ({ children, onClick, 'data-testid': testId, ...otherPr
   );
 
   return (
-    <StyledListItem {...otherProps} onClick={click} data-testid={buildTestId()}>
+    <StyledListItem {...otherProps} onClick={click} data-testid={buildTestId(testId)}>
       {children}
     </StyledListItem>
   );

--- a/src/components/Select/component.stories.tsx
+++ b/src/components/Select/component.stories.tsx
@@ -87,6 +87,7 @@ export const Responsive = () => {
           <Select.DefaultTarget
             onClick={() => setOpen((value) => !value)}
             left={selected ? <selected.icon /> : undefined}
+            data-testid="select.default-target"
           >
             {selected ? selected.label : placeholder}
           </Select.DefaultTarget>
@@ -127,6 +128,7 @@ export const Dropdown = () => {
           <Select.DefaultTarget
             onClick={() => setOpen((value) => !value)}
             left={selected ? <selected.icon /> : undefined}
+            data-testid="select.default-target"
           >
             {selected ? selected.label : placeholder}
           </Select.DefaultTarget>
@@ -169,7 +171,10 @@ export const Modal = () => {
         open={open}
         onClose={() => setOpen(false)}
         target={
-          <Select.DefaultTarget onClick={() => setOpen((value) => !value)}>
+          <Select.DefaultTarget
+            onClick={() => setOpen((value) => !value)}
+            data-testid="select.default-target"
+          >
             {selected ? selected : placeholder}
           </Select.DefaultTarget>
         }

--- a/src/components/Steps/Connector/component.tsx
+++ b/src/components/Steps/Connector/component.tsx
@@ -1,21 +1,17 @@
 import React, { useContext } from 'react';
 
-import { useBuildTestId, Testable } from '../../../modules/test-ids';
 import { Context } from '../context';
 
 import { Styled } from './styled';
 
-export type Props = Testable & {
+export type Props = {
   size?: number;
 };
 
-export const Component = ({ size, 'data-testid': testId, ...otherProps }: Props) => {
-  const { buildTestId } = useBuildTestId({ id: testId });
+export const Component = ({ size, ...otherProps }: Props) => {
   const { orientation } = useContext(Context);
 
-  return (
-    <Styled {...otherProps} size={size} $orientation={orientation} data-testid={buildTestId()} />
-  );
+  return <Styled {...otherProps} size={size} $orientation={orientation} />;
 };
 
 Component.displayName = 'Steps.Connector';

--- a/src/components/Steps/Item/component.tsx
+++ b/src/components/Steps/Item/component.tsx
@@ -4,19 +4,28 @@ import { em } from 'polished';
 
 import { useBuildTestId, Testable } from '../../../modules/test-ids';
 import { Icon } from '../../Icon';
+import { Context } from '../context';
 
-import { Context } from './context';
+import { Context as ItemContext } from './context';
 import { Styled, Pulse } from './styled';
 
 export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as'> & Testable;
 
 export const Component = ({ children, 'data-testid': testId, ...otherProps }: Props) => {
-  const { buildTestId } = useBuildTestId({ id: testId });
+  const { testId: parentTestId } = useContext(Context);
+  const { buildTestId } = useBuildTestId({
+    id: testId ? parentTestId : undefined,
+  });
+  const { active, completed } = useContext(ItemContext);
   const theme = useTheme();
-  const { active, completed } = useContext(Context);
 
   return (
-    <Styled {...otherProps} active={!!active} completed={!!completed} data-testid={buildTestId()}>
+    <Styled
+      {...otherProps}
+      active={!!active}
+      completed={!!completed}
+      data-testid={buildTestId(testId)}
+    >
       {completed ? (
         <Icon.Tick fontSize={em(theme.honeycomb.size.tiny, theme.honeycomb.size.small)} />
       ) : (

--- a/src/components/Steps/component.stories.tsx
+++ b/src/components/Steps/component.stories.tsx
@@ -17,11 +17,17 @@ export default {
 const renderItems = (key: string) => {
   return (
     <>
-      <Steps.Item key={`${key}-1`}>1</Steps.Item>
-      <Steps.Connector />
-      <Steps.Item key={`${key}-2`}>2</Steps.Item>
-      <Steps.Connector />
-      <Steps.Item key={`${key}-3`}>3</Steps.Item>
+      <Steps.Item key={`${key}-1`} data-testid={`${key}-1`}>
+        1
+      </Steps.Item>
+      <Steps.Connector data-testid={`${key}-1.connector`} />
+      <Steps.Item key={`${key}-2`} data-testid={`${key}-2`}>
+        2
+      </Steps.Item>
+      <Steps.Connector data-testid={`${key}-2.connector`} />
+      <Steps.Item key={`${key}-3`} data-testid={`${key}-3`}>
+        3
+      </Steps.Item>
     </>
   );
 };
@@ -42,7 +48,7 @@ export const Horizontal = () => {
         const key = `steps-${index}`;
 
         return (
-          <Steps key={key} orientation="horizontal" activeStep={index - 1}>
+          <Steps key={key} orientation="horizontal" activeStep={index - 1} data-testid={key}>
             {renderItems(key)}
           </Steps>
         );

--- a/src/components/Steps/component.tsx
+++ b/src/components/Steps/component.tsx
@@ -21,7 +21,7 @@ export const Component = ({
   ...otherProps
 }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
-  const context = useMemo(() => ({ orientation }), [orientation]);
+  const context = useMemo(() => ({ orientation, testId }), [orientation, testId]);
 
   const steps = useMemo(() => {
     const children = React.Children.toArray(otherProps.children);

--- a/src/components/Steps/context.tsx
+++ b/src/components/Steps/context.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 
 import { Orientation } from './styled';
 
-export const Context = React.createContext<{ orientation: Orientation }>({
+export const Context = React.createContext<{ orientation: Orientation; testId?: string }>({
   orientation: 'horizontal',
 });

--- a/src/components/Swiper/Item/component.tsx
+++ b/src/components/Swiper/Item/component.tsx
@@ -1,14 +1,18 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { SwiperSlide } from 'swiper/react';
 
 import { useBuildTestId, Testable } from '../../../modules/test-ids';
+import { Context } from '../context';
 
 export type Props = React.ComponentProps<typeof SwiperSlide> & Testable;
 
 export const Component = ({ 'data-testid': testId, ...otherProps }: Props) => {
-  const { buildTestId } = useBuildTestId({ id: testId });
+  const { testId: parentTestId } = useContext(Context);
+  const { buildTestId } = useBuildTestId({
+    id: testId ? parentTestId : undefined,
+  });
 
-  return <SwiperSlide {...otherProps} data-testid={buildTestId()} />;
+  return <SwiperSlide {...otherProps} data-testid={buildTestId(testId)} />;
 };
 
 // The `swiper` code uses `displayName` to render slides correctly, so we cannot change it.

--- a/src/components/Swiper/component.stories.tsx
+++ b/src/components/Swiper/component.stories.tsx
@@ -38,10 +38,10 @@ export const Default = () => {
   return (
     <Swiper data-testid={buildTestId()}>
       {new Array(5).fill(null).map((_, index) => (
-        <Swiper.Item data-testid={buildTestId(`item-${index}`)}>
+        <Swiper.Item data-testid={`${index}`}>
           <Container>
             <img alt="" src={placeholder} width="100%" />
-            <Label data-testid={buildTestId(`item-${index}.label`)}>{index + 1}</Label>
+            <Label data-testid={buildTestId(`${index}.label`)}>{index + 1}</Label>
           </Container>
         </Swiper.Item>
       ))}

--- a/src/components/Swiper/component.tsx
+++ b/src/components/Swiper/component.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import SwiperCore, { Navigation, Pagination } from 'swiper';
 import { Swiper } from 'swiper/react';
 
 import { Testable, useBuildTestId } from '../../modules/test-ids';
 
+import { Context } from './context';
 import { MARGIN_WIDTH, Styled, Styles } from './styled';
 
 SwiperCore.use([Navigation, Pagination]);
@@ -16,9 +17,10 @@ export type Props = Omit<
 
 export const Component = ({ children, 'data-testid': testId, ...otherProps }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
+  const context = useMemo(() => ({ testId }), [testId]);
 
   return (
-    <>
+    <Context.Provider value={context}>
       <Styles />
       <Styled
         {...otherProps}
@@ -44,7 +46,7 @@ export const Component = ({ children, 'data-testid': testId, ...otherProps }: Pr
         <div className="swiper-button-next" data-testid={buildTestId('btn-next')}></div>
         <div className="swiper-pagination" data-testid={buildTestId('pagination')}></div>
       </Styled>
-    </>
+    </Context.Provider>
   );
 };
 

--- a/src/components/Swiper/context.tsx
+++ b/src/components/Swiper/context.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const Context = React.createContext<{ testId?: string }>({});


### PR DESCRIPTION
Related: [#793](https://github.com/binance-chain/ui-project-management/issues/793).

Components with helper children (`Dropdown`, `PanelControl`, `Select`, `Steps`, `Swiper`) should have a consistent test ID format.

```
// Example
<Swiper data-testid="swiper">
  <Swiper.Item data-testid="0"> // --> "swiper.0", parent test ID is automatically inferred.
</Swiper>

<Steps data-testid="steps">
  <Steps.Item data-testid="0"> // --> "steps.0"
</Steps>

<Select data-testid="select">
  <Select.DefaultTarget data-testid="default-target"> // --> "default-target", does not infer parent test ID.
  <Select.Option data-testid="0"> // --> "select0"
</Select>
```