### PR TITLE
fix(Modal): Library types being non-optional once released

### DIFF
--- a/src/components/Modal/component.tsx
+++ b/src/components/Modal/component.tsx
@@ -32,18 +32,16 @@ const MODAL_CONTAINER =
 
 const PARENT_SELECTOR = !!MODAL_CONTAINER ? () => MODAL_CONTAINER : undefined;
 
-export type Props = Pick<
-  React.ComponentProps<typeof ReactModal>,
-  'shouldCloseOnEsc' | 'shouldCloseOnOverlayClick'
-> &
-  Testable & {
-    open?: boolean;
-    children?: React.ReactNode;
-    className?: string;
-    loading?: boolean;
-    position?: Position;
-    onClose?: () => void;
-  };
+export type Props = Testable & {
+  open?: boolean;
+  children?: React.ReactNode;
+  className?: string;
+  loading?: boolean;
+  position?: Position;
+  closeOnEsc?: boolean;
+  closeOnBackgroundClick?: boolean;
+  onClose?: () => void;
+};
 
 export const Component = ({
   open = false,
@@ -51,10 +49,10 @@ export const Component = ({
   className,
   loading,
   position = 'center',
-  shouldCloseOnOverlayClick = false,
+  closeOnEsc = true,
+  closeOnBackgroundClick = false,
   onClose,
   'data-testid': testId,
-  ...otherProps
 }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
 
@@ -91,14 +89,14 @@ export const Component = ({
   return (
     <>
       <ReactModal
-        {...otherProps}
         isOpen={open}
         onRequestClose={close}
         className={className}
         parentSelector={PARENT_SELECTOR}
         appElement={MODAL_CONTAINER}
         closeTimeoutMS={CLOSE_MODAL_TIMEOUT}
-        shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
+        shouldCloseOnEsc={closeOnEsc}
+        shouldCloseOnOverlayClick={closeOnBackgroundClick}
         contentElement={(props, contentElement) => (
           <>
             {boxTransitions.map(({ item, props: transitionProps, key }) =>

--- a/src/cypress/Modal.stories.tsx
+++ b/src/cypress/Modal.stories.tsx
@@ -39,14 +39,14 @@ export const Default = () => {
           <Modal
             open={showInner}
             onClose={() => setShowInner(false)}
-            shouldCloseOnOverlayClick={false}
+            closeOnBackgroundClick={false}
             data-testid="modal-inner"
           >
             <Modal.Header title="Inner Modal" />
             <Modal.Content>
               <Guide size="reduced">
                 If you put an element like <Code>Dropdown</Code> inside a modal, make sure
-                <Code>shouldCloseOnOverlayClick=&#123;false&#125;</Code> (default).
+                <Code>closeOnBackgroundClick=&#123;false&#125;</Code> (default).
               </Guide>
               <Guide size="reduced">
                 Otherwise the modal will be closed when clicking outside of the dropdown.


### PR DESCRIPTION
Once the package is released, the props picked from `ReactModal` lose their optional-ness. Error:
`Type ... is missing the following properties from type ...: shouldCloseOnEsc, shouldCloseOnOverlayClick`.

This PR uses our own props and passes them down to `ReactModal`, which should solve this issue.