### PR TITLE
fix(Button): Apply disabled styles when button is an anchor

### DIFF
--- a/src/components/Button/component.stories.tsx
+++ b/src/components/Button/component.stories.tsx
@@ -108,6 +108,9 @@ export const AsAnchor = () => (
         </Container>
       )),
     )}
+    <Button href="https://binance.org" onClick={action('clicked')} variant="primary" disabled>
+      disabled
+    </Button>
   </Container>
 );
 

--- a/src/components/Button/styled.tsx
+++ b/src/components/Button/styled.tsx
@@ -144,10 +144,12 @@ export const Styled = styled.button<Props>`
     text-decoration: none;
   }
 
-  :disabled {
-    opacity: 0.3;
-    pointer-events: none;
-  }
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      opacity: 0.3;
+      pointer-events: none;
+    `};
 
   ${({ variant }) => variant === 'success' && success};
   ${({ variant }) => variant === 'buy' && buy};


### PR DESCRIPTION
`:disabled` CSS selector does not apply when the button is an anchor, so we should apply the styles using props.