### PR TITLE
feat(Dropdown): Add optional `bare` prop like `Tooltip`

### DIFF
--- a/src/components/Dropdown/component.stories.tsx
+++ b/src/components/Dropdown/component.stories.tsx
@@ -15,7 +15,11 @@ export default {
 };
 
 export const Bare = () => {
-  return <Dropdown target="Dropdown">Some content...</Dropdown>;
+  return (
+    <Dropdown target="Dropdown" bare>
+      Some content...
+    </Dropdown>
+  );
 };
 
 export const WithHelpers = () => {

--- a/src/components/Dropdown/component.tsx
+++ b/src/components/Dropdown/component.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from '../Tooltip';
 import { Styleless } from '../Styleless';
 
 import { Context, ContentContext } from './context';
-import { TooltipContent } from './styled';
+import { Content } from './styled';
 
 export type TriggerValue = 'mouseenter' | 'focus' | 'click';
 
@@ -39,7 +39,7 @@ export const Component = ({
       return children;
     }
 
-    return <TooltipContent>{children}</TooltipContent>;
+    return <Content>{children}</Content>;
   }, [bare, children]);
 
   return (

--- a/src/components/Dropdown/component.tsx
+++ b/src/components/Dropdown/component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 
 import { Testable, useBuildTestId } from '../../modules/test-ids';
 import { Tooltip } from '../Tooltip';
@@ -10,7 +10,7 @@ import { TooltipContent } from './styled';
 export type TriggerValue = 'mouseenter' | 'focus' | 'click';
 
 export type Props = Pick<React.HTMLAttributes<HTMLElement>, 'className' | 'children'> &
-  Pick<React.ComponentPropsWithoutRef<typeof Tooltip>, 'radius' | 'appendTo'> &
+  Pick<React.ComponentPropsWithoutRef<typeof Tooltip>, 'appendTo' | 'bare' | 'radius'> &
   Testable & {
     target: React.ReactNode;
     onClick?: () => void;
@@ -20,6 +20,7 @@ export const Component = ({
   children,
   className,
   target,
+  bare,
   radius = 'normal',
   onClick,
   'data-testid': testId,
@@ -33,22 +34,31 @@ export const Component = ({
     onClick?.();
   }, [onClick]);
 
+  const content = useMemo(() => {
+    if (bare) {
+      return children;
+    }
+
+    return <TooltipContent>{children}</TooltipContent>;
+  }, [bare, children]);
+
   return (
     <Context.Provider value={{ isShowing, onClose: click }}>
       <Tooltip
-        radius={radius}
         {...otherProps}
         className={className}
         interactive={true}
         visible={isShowing}
         content={
           <ContentContext.Provider value={{ testId: buildTestId() }}>
-            <TooltipContent>{children}</TooltipContent>
+            {content}
           </ContentContext.Provider>
         }
-        data-testid={buildTestId()}
         onClickOutside={click}
+        bare={bare}
         padding="none"
+        radius={radius}
+        data-testid={buildTestId()}
       >
         <Styleless htmlTag="div" onClick={click}>
           {target}

--- a/src/components/Dropdown/styled.tsx
+++ b/src/components/Dropdown/styled.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { em } from 'polished';
 
-export const TooltipContent = styled.div`
+export const Content = styled.div`
   display: flex;
   flex-direction: column;
   min-width: ${({ theme }) => em(200, theme.honeycomb.size.reduced)};


### PR DESCRIPTION
We need this for the extension, otherwise it gets complicated making custom dropdowns and having to undo all of the styles the component applies by default. `Tooltip` has this prop, so now `Dropdown` matches.