### PR TITLE
fix(Modal): Fix memory leak caused by modal close transition (#877)

### DIFF
--- a/src/components/Modal/component.tsx
+++ b/src/components/Modal/component.tsx
@@ -96,6 +96,24 @@ export const Component = ({
         closeTimeoutMS={CLOSE_MODAL_TIMEOUT}
         shouldCloseOnEsc={closeOnEsc}
         shouldCloseOnOverlayClick={closeOnBackgroundClick}
+        contentElement={(props, contentElement) => (
+          <>
+            {boxTransitions.map(({ item, props: transitionProps, key }) =>
+              item ? (
+                <Box
+                  {...props}
+                  as={animated.div}
+                  key={key}
+                  style={transitionProps}
+                  position={position}
+                  data-testid={buildTestId()}
+                >
+                  {contentElement}
+                </Box>
+              ) : null,
+            )}
+          </>
+        )}
         overlayElement={(props, contentElement) => (
           <>
             {containerTransitions.map(({ item, props: transitionProps, key }) =>

--- a/src/components/Modal/component.tsx
+++ b/src/components/Modal/component.tsx
@@ -96,24 +96,6 @@ export const Component = ({
         closeTimeoutMS={CLOSE_MODAL_TIMEOUT}
         shouldCloseOnEsc={closeOnEsc}
         shouldCloseOnOverlayClick={closeOnBackgroundClick}
-        contentElement={(props, contentElement) => (
-          <>
-            {boxTransitions.map(({ item, props: transitionProps, key }) =>
-              item ? (
-                <Box
-                  {...props}
-                  as={animated.div}
-                  key={key}
-                  style={transitionProps}
-                  position={position}
-                  data-testid={buildTestId()}
-                >
-                  {contentElement}
-                </Box>
-              ) : null,
-            )}
-          </>
-        )}
         overlayElement={(props, contentElement) => (
           <>
             {containerTransitions.map(({ item, props: transitionProps, key }) =>
@@ -126,7 +108,19 @@ export const Component = ({
           </>
         )}
       >
-        <Context.Provider value={context}>{children}</Context.Provider>
+        {boxTransitions.map(({ item, props: transitionProps, key }) =>
+          item ? (
+            <Box
+              as={animated.div}
+              key={key}
+              style={transitionProps}
+              position={position}
+              data-testid={buildTestId()}
+            >
+              <Context.Provider value={context}>{children}</Context.Provider>
+            </Box>
+          ) : null,
+        )}
       </StyledReactModal>
     </>
   );

--- a/src/components/Modal/component.tsx
+++ b/src/components/Modal/component.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useMemo } from 'react';
-import { useTransition, animated } from 'react-spring';
+import ReactModal from 'react-modal';
 
 import { Testable, useBuildTestId } from '../../modules/test-ids';
 
-import { StyledReactModal, Box, Container, Position } from './styled';
+import { Box, CLOSE_MODAL_TIMEOUT, Container, Position, Styles } from './styled';
 import { Context } from './context';
-
-const CLOSE_MODAL_TIMEOUT = 250;
 
 const MODAL_CONTAINER_ID = 'honeycomb-modal';
 
@@ -57,26 +55,6 @@ export const Component = ({
 
   const context = useMemo(() => ({ loading, onClose, testId }), [loading, onClose, testId]);
 
-  const containerTransitions = useTransition(open, null, {
-    initial: open ? { opacity: 1 } : { opacity: 0 },
-    from: { opacity: 0 },
-    enter: { opacity: 1 },
-    leave: { opacity: 0 },
-  });
-
-  const boxOpen = { opacity: 1, transform: position === 'center' ? 'scale(1)' : 'translateY(0)' };
-  const boxClosed = {
-    opacity: 0,
-    transform: position === 'center' ? 'scale(0.5)' : 'translateY(100vh)',
-  };
-
-  const boxTransitions = useTransition(open, null, {
-    initial: open ? boxOpen : boxClosed,
-    from: boxClosed,
-    enter: boxOpen,
-    leave: boxClosed,
-  });
-
   const close = useCallback(
     (evt: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<Element>) => {
       evt.stopPropagation();
@@ -87,7 +65,8 @@ export const Component = ({
 
   return (
     <>
-      <StyledReactModal
+      <Styles position={position} />
+      <ReactModal
         isOpen={open}
         onRequestClose={close}
         className={className}
@@ -97,49 +76,18 @@ export const Component = ({
         shouldCloseOnEsc={closeOnEsc}
         shouldCloseOnOverlayClick={closeOnBackgroundClick}
         contentElement={(props, contentElement) => (
-          <>
-            {boxTransitions.map(({ item, props: transitionProps, key }) =>
-              item ? (
-                <Box
-                  {...props}
-                  as={animated.div}
-                  key={key}
-                  style={transitionProps}
-                  position={position}
-                  data-testid={buildTestId()}
-                >
-                  {contentElement}
-                </Box>
-              ) : null,
-            )}
-          </>
+          <Box {...props} style={{}} position={position} data-testid={buildTestId()}>
+            {contentElement}
+          </Box>
         )}
         overlayElement={(props, contentElement) => (
-          <>
-            {containerTransitions.map(({ item, props: transitionProps, key }) =>
-              item ? (
-                <Container {...props} as={animated.div} key={key} style={transitionProps}>
-                  {contentElement}
-                </Container>
-              ) : null,
-            )}
-          </>
+          <Container {...props} style={{}}>
+            {contentElement}
+          </Container>
         )}
       >
-        {boxTransitions.map(({ item, props: transitionProps, key }) =>
-          item ? (
-            <Box
-              as={animated.div}
-              key={key}
-              style={transitionProps}
-              position={position}
-              data-testid={buildTestId()}
-            >
-              <Context.Provider value={context}>{children}</Context.Provider>
-            </Box>
-          ) : null,
-        )}
-      </StyledReactModal>
+        <Context.Provider value={context}>{children}</Context.Provider>
+      </ReactModal>
     </>
   );
 };

--- a/src/components/Modal/styled.tsx
+++ b/src/components/Modal/styled.tsx
@@ -1,9 +1,10 @@
-import styled, { css } from 'styled-components';
-import { em } from 'polished';
-import ReactModal from 'react-modal';
+import styled, { createGlobalStyle, css } from 'styled-components';
+import { em, transitions } from 'polished';
 
 import { boxSizing } from '../../modules/box-sizing';
 import { SIZES } from '../internal/useWindowSize';
+
+export const CLOSE_MODAL_TIMEOUT = 250;
 
 export const PADDING = ['normal', 'none'] as const;
 export type Padding = typeof PADDING[number];
@@ -13,9 +14,52 @@ export type Position = typeof POSITIONS[number];
 
 export const mdScreen = `min-width: ${em(SIZES.md)}`;
 
-export const StyledReactModal = styled(ReactModal)`
-  :focus {
-    outline: none;
+export interface Props {
+  position: Position;
+}
+
+const overlayOpen = css`
+  opacity: 1;
+`;
+
+const overlayClose = css`
+  opacity: 0;
+`;
+
+const contentOpen = css<Props>`
+  opacity: 1;
+  transform: ${({ position }) => (position === 'center' ? 'scale(1)' : 'translateY(0)')};
+`;
+
+const contentClose = css<Props>`
+  opacity: 0;
+  transform: ${({ position }) => (position === 'center' ? 'scale(0.9)' : 'translateY(100vh)')};
+`;
+
+export const Styles = createGlobalStyle<Props>`
+  .ReactModal__Overlay {
+    ${overlayClose};
+    ${transitions(['opacity'], `${CLOSE_MODAL_TIMEOUT}ms`)};
+  }
+  .ReactModal__Overlay--after-open {
+    ${overlayOpen};
+  }
+  .ReactModal__Overlay--before-close {
+    ${overlayClose};
+  }
+  .ReactModal__Content {
+    ${contentClose};
+    ${transitions(['opacity', 'transform'], `${CLOSE_MODAL_TIMEOUT}ms`)};
+
+    :focus {
+      outline: none;
+    }
+  }
+  .ReactModal__Content--after-open {
+    ${contentOpen};
+  }
+  .ReactModal__Content--before-close {
+    ${contentClose};
   }
 `;
 

--- a/src/cypress/Modal.stories.tsx
+++ b/src/cypress/Modal.stories.tsx
@@ -1,15 +1,12 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { em } from 'polished';
-import { action } from '@storybook/addon-actions';
 
 import { Button } from '../components/Button';
 import { Dropdown } from '../components/Dropdown';
 import { Code } from '../components/internal/Docs';
 import { Modal } from '../components/Modal';
-import { Space } from '../components/Space';
 import { Text } from '../components/Text';
-import { TextInput } from '../components/TextInput';
 import { Sections } from '../modules/sections';
 
 const appendTo = typeof document === 'undefined' ? undefined : document.body;
@@ -69,68 +66,6 @@ export const Default = () => {
           </Modal>
         </Modal.Content>
       </Modal>
-    </>
-  );
-};
-
-type Props = Pick<React.ComponentProps<typeof Modal>, 'open' | 'onClose'> &
-  Pick<React.ComponentProps<typeof Modal.Header>, 'title'> & {
-    defaultName?: string;
-    callback: ({ name }: { name: string }) => void;
-  };
-
-const MemoryLeak = ({ open, onClose, title, defaultName, callback }: Props) => {
-  const [name, setName] = useState('');
-
-  useEffect(() => {
-    if (!defaultName) return;
-    setName(defaultName);
-  }, [defaultName]);
-
-  const change = useCallback<NonNullable<React.ComponentProps<typeof TextInput>['onChange']>>(
-    (evt) => setName(evt.target.value),
-    [],
-  );
-
-  const confirm = useCallback(() => {
-    callback({ name });
-    setName('');
-    onClose?.();
-  }, [name, callback, onClose]);
-
-  return (
-    <Modal open={open} onClose={onClose}>
-      <Modal.Header title={title} />
-      <Modal.Content>
-        <TextInput value={name} label="Label" onChange={change} />
-        <Space size="increased" />
-        <Button variant="secondary" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button variant="primary" onClick={confirm}>
-          Confirm
-        </Button>
-      </Modal.Content>
-    </Modal>
-  );
-};
-
-export const MemoryLeakTest = () => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const open = useCallback(() => setIsOpen(true), []);
-  const close = useCallback(() => setIsOpen(false), []);
-
-  const callback = useCallback(({ name }: { name: string }) => {
-    action(name)();
-  }, []);
-
-  return (
-    <>
-      <Button variant="primary" onClick={open}>
-        Open
-      </Button>
-      <MemoryLeak open={isOpen} onClose={close} title="Memory Leak Modal" callback={callback} />
     </>
   );
 };


### PR DESCRIPTION
Issue [#877](https://github.com/binance-chain/ui-project-management/issues/877).

This issue is due to using the `react-spring` library for animations when opening and closing the modal. When the modal closes, it is unmounted and we get a `Can't perform a React state update on an unmounted component...indicates a memory leak` warning. This PR converts all of the animations `react-spring` applied into CSS.