### PR TITLE
refactor(Toast): Rename `Toaster` to `ToastProvider`

### DIFF
--- a/cypress/integration/Toast.ts
+++ b/cypress/integration/Toast.ts
@@ -1,7 +1,7 @@
-describe('Toaster', () => {
+describe('Toast', () => {
   it('renders correctly on small screens', () => {
     cy.clock();
-    cy.visitStory({ storyId: 'elements-toaster--default', themeId: 'GoldLight' });
+    cy.visitStory({ storyId: 'elements-toast--default', themeId: 'GoldLight' });
 
     cy.get('[data-testid="success-btn"]').click();
     cy.get('[data-testid="warning-btn"]').click();
@@ -12,13 +12,13 @@ describe('Toaster', () => {
     cy.get('[data-testid="warning-toast"]').should('be.visible');
     cy.get('[data-testid="danger-toast"]').should('be.visible');
 
-    cy.percySnapshot('Toaster while open on a small screen');
+    cy.percySnapshot('Toast while open on a small screen');
   });
 
   it('renders correctly on medium screens', () => {
     cy.customViewport({ size: 'md' });
     cy.clock();
-    cy.visitStory({ storyId: 'elements-toaster--default', themeId: 'GoldLight' });
+    cy.visitStory({ storyId: 'elements-toast--default', themeId: 'GoldLight' });
 
     cy.get('[data-testid="success-btn"]').click();
     cy.get('[data-testid="warning-btn"]').click();
@@ -29,6 +29,6 @@ describe('Toaster', () => {
     cy.get('[data-testid="warning-toast"]').should('be.visible');
     cy.get('[data-testid="danger-toast"]').should('be.visible');
 
-    cy.percySnapshot('Toaster while open on a medium screen', { widths: [768] });
+    cy.percySnapshot('Toast while open on a medium screen', { widths: [768] });
   });
 });

--- a/src/components/Toast/actions/index.tsx
+++ b/src/components/Toast/actions/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { toast, ToastOptions } from 'react-toastify';
 
-import { Toaster } from '../../Toaster';
-import { AUTO_CLOSE_DEFAULT_DURATION } from '../../Toaster/component';
+import { ToastProvider } from '../../../modules/toast/ToastProvider';
+import { AUTO_CLOSE_DEFAULT_DURATION } from '../../../modules/toast/ToastProvider/component';
 
 import { Size, Styled } from './styled';
 
-type Options = Pick<React.ComponentProps<typeof Toaster>, 'autoClose'> & {
+type Options = Pick<React.ComponentProps<typeof ToastProvider>, 'autoClose'> & {
   position?: ToastOptions['position'];
   toastId?: ToastOptions['toastId'];
   onOpen?: ToastOptions['onOpen'];

--- a/src/components/Toast/component.stories.tsx
+++ b/src/components/Toast/component.stories.tsx
@@ -7,6 +7,7 @@ import { Sections } from '../../modules/sections';
 import { HoneycombThemeProvider } from '../../modules/themes';
 import { GoldLight } from '../../modules/themes/themes/GoldLight';
 import { Variant } from '../../modules/themes/HoneycombThemeProvider';
+import { ToastProvider } from '../../modules/toast';
 import { Button } from '../Button';
 import { Card } from '../Card';
 import { Dropdown } from '../Dropdown';
@@ -14,13 +15,12 @@ import { Header } from '../Header';
 import { Icon } from '../Icon';
 import { Code } from '../internal/Docs';
 import { Text } from '../Text';
-import { createToast, dismissToast, Toast } from '../Toast';
 
-import { Toaster } from './';
+import { createToast, dismissToast, Toast } from './';
 
 export default {
-  component: Toaster,
-  title: `${Sections.Elements}/Toaster`,
+  component: Toast,
+  title: `${Sections.Elements}/Toast`,
 };
 
 const Container = styled.div`
@@ -43,7 +43,7 @@ const makeToast = () =>
 
 export const Default = () => (
   <>
-    <Toaster autoClose={false} />
+    <ToastProvider autoClose={false} />
     <Container>
       <Button
         variant="success"
@@ -148,12 +148,12 @@ export const Variants = () => {
     );
   }, []);
 
-  return <Toaster autoClose={false} position="top-right" />;
+  return <ToastProvider autoClose={false} position="top-right" />;
 };
 
 export const WithCallback = () => (
   <>
-    <Toaster position="top-right" />
+    <ToastProvider position="top-right" />
     <Button
       variant="primary"
       onClick={() =>
@@ -168,7 +168,7 @@ export const WithCallback = () => (
   </>
 );
 
-const StyledToaster = styled(Toaster)`
+const StyledToaster = styled(ToastProvider)`
   transform: translateY(calc(4em + 12px));
 `;
 
@@ -195,7 +195,7 @@ export const WithTheme = () => {
 
   return (
     <HoneycombThemeProvider variant={selected}>
-      <Toaster position="top-right" />
+      <ToastProvider position="top-right" />
       <Card>
         <Dropdown target={<Dropdown.DefaultTarget>{selected}</Dropdown.DefaultTarget>}>
           {['accent', 'dark', 'light'].map((it) => (
@@ -221,7 +221,7 @@ export const DismissToast = () => {
 
   return (
     <>
-      <Toaster autoClose={false} position="top-right" />
+      <ToastProvider autoClose={false} position="top-right" />
       <Container>
         <Button
           variant="primary"

--- a/src/components/Toast/component.stories.tsx
+++ b/src/components/Toast/component.stories.tsx
@@ -7,7 +7,7 @@ import { Sections } from '../../modules/sections';
 import { HoneycombThemeProvider } from '../../modules/themes';
 import { GoldLight } from '../../modules/themes/themes/GoldLight';
 import { Variant } from '../../modules/themes/HoneycombThemeProvider';
-import { ToastProvider } from '../../modules/toast';
+import { createToast, dismissToast, ToastProvider } from '../../modules/toast';
 import { Button } from '../Button';
 import { Card } from '../Card';
 import { Dropdown } from '../Dropdown';
@@ -16,7 +16,7 @@ import { Icon } from '../Icon';
 import { Code } from '../internal/Docs';
 import { Text } from '../Text';
 
-import { createToast, dismissToast, Toast } from './';
+import { Toast } from './';
 
 export default {
   component: Toast,

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,6 +1,5 @@
 import { Component } from './component';
 import { Icon } from './Icon';
-export { createToast, dismissToast } from '../Toast/actions';
 
 export const Toast = Component as typeof Component & { Icon: typeof Icon };
 

--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -1,1 +1,0 @@
-export { Component as Toaster } from './component';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ export {
 } from './modules/core';
 export { useBreadcrumbs, useAddBreadcrumbEffect, BreadcrumbProvider } from './modules/breadcrumbs';
 export { useBuildTestId, Testable } from './modules/test-ids';
-export { ToastProvider } from './modules/toast';
+export { createToast, dismissToast, ToastProvider } from './modules/toast';
 export { useMoonPayUrl, buildMoonPayUrl } from './modules/moonpay';
 export { formatCryptoAsset, formatFiatAsset } from './modules/intl';
 
@@ -53,6 +53,6 @@ export { Table } from './components/Table';
 export { Text } from './components/Text';
 export { TextArea } from './components/TextArea';
 export { TextInput } from './components/TextInput';
-export { createToast, dismissToast, Toast } from './components/Toast';
+export { Toast } from './components/Toast';
 export { Tooltip } from './components/Tooltip';
 export { Wallets, useWalletProviders } from './components/Wallets';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ export {
 } from './modules/core';
 export { useBreadcrumbs, useAddBreadcrumbEffect, BreadcrumbProvider } from './modules/breadcrumbs';
 export { useBuildTestId, Testable } from './modules/test-ids';
+export { ToastProvider } from './modules/toast';
 export { useMoonPayUrl, buildMoonPayUrl } from './modules/moonpay';
 export { formatCryptoAsset, formatFiatAsset } from './modules/intl';
 
@@ -53,6 +54,5 @@ export { Text } from './components/Text';
 export { TextArea } from './components/TextArea';
 export { TextInput } from './components/TextInput';
 export { createToast, dismissToast, Toast } from './components/Toast';
-export { Toaster } from './components/Toaster';
 export { Tooltip } from './components/Tooltip';
 export { Wallets, useWalletProviders } from './components/Wallets';

--- a/src/modules/toast/ToastProvider/component.tsx
+++ b/src/modules/toast/ToastProvider/component.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from 'react';
 import { Slide, ToastContainer } from 'react-toastify';
 
-import { Testable, useBuildTestId } from '../../modules/test-ids';
-import { Icon } from '../Icon';
+import { Testable, useBuildTestId } from '../../test-ids';
+import { Icon } from '../../../components/Icon';
 
 import { StyledToastContainer, StyledButton, Styles } from './styled';
 
@@ -60,4 +60,4 @@ export const Component = ({
   );
 };
 
-Component.displayName = 'Toaster';
+Component.displayName = 'ToastProvider';

--- a/src/modules/toast/ToastProvider/index.tsx
+++ b/src/modules/toast/ToastProvider/index.tsx
@@ -1,0 +1,1 @@
+export { Component as ToastProvider } from './component';

--- a/src/modules/toast/ToastProvider/styled.tsx
+++ b/src/modules/toast/ToastProvider/styled.tsx
@@ -2,9 +2,9 @@ import styled, { createGlobalStyle } from 'styled-components';
 import { em } from 'polished';
 import { ToastContainer } from 'react-toastify';
 
-import toastify from '../../../node_modules/react-toastify/dist/ReactToastify.min.css';
-import { Button } from '../Button';
-import { SIZES } from '../internal/useWindowSize';
+import toastify from '../../../../node_modules/react-toastify/dist/ReactToastify.min.css';
+import { Button } from '../../../components/Button';
+import { SIZES } from '../../../components/internal/useWindowSize';
 
 const TOAST_HEIGHT = 56;
 

--- a/src/modules/toast/actions/index.tsx
+++ b/src/modules/toast/actions/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { toast, ToastOptions } from 'react-toastify';
 
-import { ToastProvider } from '../../../modules/toast/ToastProvider';
-import { AUTO_CLOSE_DEFAULT_DURATION } from '../../../modules/toast/ToastProvider/component';
+import { ToastProvider } from '../ToastProvider';
+import { AUTO_CLOSE_DEFAULT_DURATION } from '../ToastProvider/component';
 
 import { Size, Styled } from './styled';
 

--- a/src/modules/toast/actions/styled.tsx
+++ b/src/modules/toast/actions/styled.tsx
@@ -1,7 +1,7 @@
 import styled, { DefaultTheme } from 'styled-components';
 import { em } from 'polished';
 
-import { SIZES as WINDOW_SIZES } from '../../internal/useWindowSize';
+import { SIZES as WINDOW_SIZES } from '../../../components/internal/useWindowSize';
 
 const WIDTHS = {
   reduced: 280,

--- a/src/modules/toast/index.tsx
+++ b/src/modules/toast/index.tsx
@@ -1,0 +1,1 @@
+export { ToastProvider } from './ToastProvider';

--- a/src/modules/toast/index.tsx
+++ b/src/modules/toast/index.tsx
@@ -1,1 +1,2 @@
+export { createToast, dismissToast } from './actions';
 export { ToastProvider } from './ToastProvider';


### PR DESCRIPTION
Rename `Toaster` to `ToastProvider` and move into the modules directory to be consistent with an upcoming module, `BreadcrumbProvider`.

I will update usage in our existing projects once this is merged.