### PR TITLE
feat(CryptoAddress): Add optional `size` prop, change layout based on screen width (#882)

### DIFF
--- a/src/components/CryptoAddress/component.stories.tsx
+++ b/src/components/CryptoAddress/component.stories.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
+import styled from 'styled-components';
+import { em } from 'polished';
 
 import { decorators } from '../../modules/decorators';
 import { Sections } from '../../modules/sections';
+
+import { SIZES } from './styled';
 
 import { CryptoAddress } from './';
 
@@ -11,14 +15,30 @@ export default {
   title: `${Sections.Elements}/CryptoAddress`,
 };
 
-export const Default = () => (
-  <CryptoAddress value="bnb000000000000000000000000000000000000000" data-testid="crypto-address" />
-);
+const ADDRESS = 'bnb000000000000000000000000000000000000000';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  > *:not(:last-child) {
+    margin-bottom: ${({ theme }) => em(theme.honeycomb.size.normal)};
+  }
+`;
+
+export const Default = () => <CryptoAddress value={ADDRESS} data-testid="crypto-address" />;
 
 export const Format = () => (
-  <CryptoAddress
-    value="bnb000000000000000000000000000000000000000"
-    text="0xb38784***e967Ece49"
-    data-testid="crypto-address"
-  />
+  <CryptoAddress value={ADDRESS} text="0xb38784***e967Ece49" data-testid="crypto-address" />
+);
+
+export const Sizes = () => (
+  <Container>
+    {SIZES.map((size) => (
+      <div>
+        <h3>{size}</h3>
+        <CryptoAddress value={ADDRESS} size={size} />
+      </div>
+    ))}
+  </Container>
 );

--- a/src/components/CryptoAddress/component.tsx
+++ b/src/components/CryptoAddress/component.tsx
@@ -1,14 +1,15 @@
 import React, { useMemo, useState } from 'react';
 
+import { Testable, useBuildTestId } from '../../modules/test-ids';
+import { Button } from '../Button';
+import { CopyToClipboard } from '../CopyToClipboard';
 import { Icon } from '../Icon';
 import { useWindowSize, SIZES } from '../internal/useWindowSize';
-import { Testable, useBuildTestId } from '../../modules/test-ids';
 import { Modal } from '../Modal';
-import { Button } from '../Button';
 import { Tooltip } from '../Tooltip';
-import { CopyToClipboard } from '../CopyToClipboard';
+import { Space } from '../Space';
 
-import { Container, CryptoAddress, StyledModal, StyledQRCode } from './styled';
+import { ButtonWrapper, Container, CryptoAddress, Size, StyledModal, StyledQRCode } from './styled';
 
 export type Props = Testable & {
   value: string;
@@ -16,6 +17,7 @@ export type Props = Testable & {
   className?: string;
   canCopyToClipboard?: boolean;
   canScanQrCode?: boolean;
+  size?: Size;
 };
 
 export const Component = ({
@@ -24,12 +26,15 @@ export const Component = ({
   className,
   canCopyToClipboard = true,
   canScanQrCode = true,
+  size = 'increased',
   'data-testid': testId,
 }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
   const [showQRCode, setShowQRCode] = useState(false);
 
   const { width } = useWindowSize();
+
+  const isSm = useMemo(() => width < SIZES.md, [width]);
 
   const qRCode = useMemo(() => {
     return (
@@ -39,59 +44,72 @@ export const Component = ({
     );
   }, [value]);
 
-  const scanQrCodeButton = (
-    <Button
-      variant="secondary"
-      shape="square"
-      size="increased"
-      onClick={() => setShowQRCode((value) => !value)}
-      data-testid={buildTestId('btn-scan-qr-code')}
-    >
-      <Icon.QRCode />
-    </Button>
+  const scanQrCodeButton = useMemo(
+    () => (
+      <Button
+        variant="secondary"
+        shape="square"
+        size={size}
+        onClick={() => setShowQRCode((value) => !value)}
+        data-testid={buildTestId('btn-scan-qr-code')}
+      >
+        <Icon.QRCode />
+      </Button>
+    ),
+    [size, buildTestId],
   );
 
   return (
     <Container className={className} data-testid={buildTestId()}>
-      <CryptoAddress data-testid={buildTestId('address')}>{text || value}</CryptoAddress>
-      {canScanQrCode && (
-        <>
-          {width < SIZES.md ? (
-            <>
-              {scanQrCodeButton}
-              <StyledModal
-                open={showQRCode}
-                onClose={() => setShowQRCode(false)}
-                data-testid={buildTestId('modal')}
-              >
-                <Modal.Header title="QR Code" />
-                {qRCode}
-              </StyledModal>
-            </>
-          ) : (
-            <Tooltip
-              placement="bottom"
-              visible={showQRCode}
-              interactive={true}
-              content={qRCode}
-              data-testid={buildTestId('tooltip')}
-              padding="none"
-              radius="normal"
-            >
-              {scanQrCodeButton}
-            </Tooltip>
-          )}
-        </>
-      )}
-      {canCopyToClipboard && (
-        <CopyToClipboard
-          value={value}
-          variant="secondary"
-          shape="square"
-          size="increased"
-          data-testid={buildTestId('btn-copy')}
-        />
-      )}
+      <CryptoAddress size={size} data-testid={buildTestId('address')}>
+        {text || value}
+      </CryptoAddress>
+      <ButtonWrapper>
+        {canScanQrCode && (
+          <>
+            {isSm ? (
+              <>
+                {scanQrCodeButton}
+                <StyledModal
+                  open={showQRCode}
+                  onClose={() => setShowQRCode(false)}
+                  data-testid={buildTestId('modal')}
+                >
+                  <Modal.Header title="QR Code" />
+                  {qRCode}
+                </StyledModal>
+              </>
+            ) : (
+              <>
+                <Space size="tiny" />
+                <Tooltip
+                  placement="bottom"
+                  visible={showQRCode}
+                  interactive={true}
+                  content={qRCode}
+                  data-testid={buildTestId('tooltip')}
+                  padding="none"
+                  radius="normal"
+                >
+                  {scanQrCodeButton}
+                </Tooltip>
+              </>
+            )}
+          </>
+        )}
+        {canCopyToClipboard && (
+          <>
+            <Space size="tiny" />
+            <CopyToClipboard
+              value={value}
+              variant="secondary"
+              shape="square"
+              size={size}
+              data-testid={buildTestId('btn-copy')}
+            />
+          </>
+        )}
+      </ButtonWrapper>
     </Container>
   );
 };

--- a/src/components/CryptoAddress/styled.tsx
+++ b/src/components/CryptoAddress/styled.tsx
@@ -1,4 +1,4 @@
-import styled, { DefaultTheme } from 'styled-components';
+import styled, { css } from 'styled-components';
 import { em } from 'polished';
 
 import { SIZES as WINDOW_SIZES } from '../internal/useWindowSize';
@@ -10,9 +10,21 @@ export const mdScreen = `min-width: ${em(WINDOW_SIZES.md)}`;
 export const SIZES = ['increased', 'huge'] as const;
 export type Size = typeof SIZES[number];
 
-const getBorderRadius = ({ theme, size }: { theme: DefaultTheme; size: Size }) => {
-  return size === 'huge' ? theme.honeycomb.radius.normal : theme.honeycomb.radius.reduced;
-};
+const increased = css`
+  height: ${({ theme }) => em(theme.honeycomb.size.increased, theme.honeycomb.size.reduced)};
+  line-height: ${({ theme }) => em(theme.honeycomb.size.increased, theme.honeycomb.size.reduced)};
+  border-radius: ${({ theme }) => em(theme.honeycomb.radius.reduced, theme.honeycomb.size.reduced)};
+  padding-left: ${({ theme }) => em(theme.honeycomb.size.tiny, theme.honeycomb.size.reduced)};
+  padding-right: ${({ theme }) => em(theme.honeycomb.size.tiny, theme.honeycomb.size.reduced)};
+`;
+
+const huge = css`
+  height: ${({ theme }) => em(theme.honeycomb.size.huge, theme.honeycomb.size.reduced)};
+  line-height: ${({ theme }) => em(theme.honeycomb.size.huge, theme.honeycomb.size.reduced)};
+  border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal, theme.honeycomb.size.reduced)};
+  padding-left: ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
+  padding-right: ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
+`;
 
 export const Container = styled.div`
   display: flex;
@@ -25,15 +37,13 @@ export const Container = styled.div`
 `;
 
 export const CryptoAddress = styled.span<{ size: Size }>`
-  background: ${({ theme }) => theme.honeycomb.color.bg.input.normal};
-  border-radius: ${({ theme, size }) =>
-    em(getBorderRadius({ theme, size }), theme.honeycomb.size.reduced)};
-  height: ${({ theme, size }) => em(theme.honeycomb.size[size], theme.honeycomb.size.reduced)};
-  line-height: ${({ theme, size }) => em(theme.honeycomb.size[size], theme.honeycomb.size.reduced)};
-  padding: 0 ${({ theme }) => em(theme.honeycomb.size.tiny, theme.honeycomb.size.reduced)};
   font-size: ${({ theme }) => em(theme.honeycomb.size.reduced)};
   overflow: hidden;
   text-overflow: ellipsis;
+  background: ${({ theme }) => theme.honeycomb.color.bg.input.normal};
+
+  ${({ size }) => size === 'increased' && increased};
+  ${({ size }) => size === 'huge' && huge};
 `;
 
 export const ButtonWrapper = styled.div`

--- a/src/components/CryptoAddress/styled.tsx
+++ b/src/components/CryptoAddress/styled.tsx
@@ -1,33 +1,50 @@
-import styled from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 import { em } from 'polished';
 
-import { boxSizing } from '../../modules/box-sizing';
+import { SIZES as WINDOW_SIZES } from '../internal/useWindowSize';
 import { Modal } from '../Modal';
 import { QRCode } from '../QRCode';
 
-export const Container = styled.div`
-  ${boxSizing};
+export const mdScreen = `min-width: ${em(WINDOW_SIZES.md)}`;
 
+export const SIZES = ['increased', 'huge'] as const;
+export type Size = typeof SIZES[number];
+
+const getBorderRadius = ({ theme, size }: { theme: DefaultTheme; size: Size }) => {
+  return size === 'huge' ? theme.honeycomb.radius.normal : theme.honeycomb.radius.reduced;
+};
+
+export const Container = styled.div`
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 
-  font-size: ${({ theme }) => em(theme.honeycomb.size.normal)};
-
-  > *:not(:last-child) {
-    margin-right: ${({ theme }) => em(theme.honeycomb.size.tiny)};
+  @media (${mdScreen}) {
+    flex-wrap: nowrap;
   }
 `;
 
-export const CryptoAddress = styled.span`
+export const CryptoAddress = styled.span<{ size: Size }>`
   background: ${({ theme }) => theme.honeycomb.color.bg.input.normal};
-  border-radius: ${({ theme }) => em(theme.honeycomb.radius.reduced, theme.honeycomb.size.reduced)};
-  height: ${({ theme }) => em(theme.honeycomb.size.increased, theme.honeycomb.size.reduced)};
-  line-height: ${({ theme }) => em(theme.honeycomb.size.increased, theme.honeycomb.size.reduced)};
+  border-radius: ${({ theme, size }) =>
+    em(getBorderRadius({ theme, size }), theme.honeycomb.size.reduced)};
+  height: ${({ theme, size }) => em(theme.honeycomb.size[size], theme.honeycomb.size.reduced)};
+  line-height: ${({ theme, size }) => em(theme.honeycomb.size[size], theme.honeycomb.size.reduced)};
   padding: 0 ${({ theme }) => em(theme.honeycomb.size.tiny, theme.honeycomb.size.reduced)};
   font-size: ${({ theme }) => em(theme.honeycomb.size.reduced)};
-  flex-shrink: 1;
   overflow: hidden;
   text-overflow: ellipsis;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  flex-basis: 100%;
+  margin-top: ${({ theme }) => em(theme.honeycomb.size.tiny)};
+
+  @media (${mdScreen}) {
+    flex-basis: auto;
+    margin-top: 0;
+  }
 `;
 
 export const StyledModal = styled(Modal)`

--- a/src/components/TextInput/component.stories.tsx
+++ b/src/components/TextInput/component.stories.tsx
@@ -143,11 +143,21 @@ export const Sizes = () => (
 );
 
 const CustomTextInput = styled(TextInput)`
+  align-items: end;
   ${TextInput.Label} {
     color: #f8bbd0;
   }
+  ${TextInput.Input} {
+    width: 100%;
+    text-align: right;
+    line-height: ${({ theme }) => em(theme.honeycomb.size.reduced, theme.honeycomb.size.small)};
+  }
+  ${TextInput.Right} {
+    margin-left: ${({ theme }) => em(theme.honeycomb.size.micro, theme.honeycomb.size.small)};
+  }
 
   ${TextInput.InputContainer} {
+    max-width: ${em(100)};
     background: #e8f5e9;
     color: #64b5f6;
 
@@ -158,5 +168,25 @@ const CustomTextInput = styled(TextInput)`
 `;
 
 export const CustomStyles = () => (
-  <CustomTextInput placeholder="Some placeholder…" label="A label" value="" />
+  <>
+    <CustomTextInput
+      placeholder="Some placeholder…"
+      label="A label"
+      value="10"
+      right="gwei"
+      size="increased"
+    />
+    <CustomTextInput
+      placeholder="Some placeholder…"
+      label="A label"
+      value="215510"
+      size="increased"
+      validationMessages={[
+        {
+          label: 'test message allalals dsjguhdsuoid sadjksah sadhlasdh',
+          state: 'danger',
+        },
+      ]}
+    />
+  </>
 );


### PR DESCRIPTION
Issue [#882](https://github.com/binance-chain/ui-project-management/issues/882).

- Add optional `size` prop.
<img width="472" alt="image" src="https://user-images.githubusercontent.com/15721063/112841888-848eaa80-90fd-11eb-93e9-8eb7e835d311.png">

- Move buttons to a new row when screen width < 768px. This was a bit complex because we use `em` and the buttons/text change font sizes based on screen width, but the spacing stays the same.
<img width="337" alt="image" src="https://user-images.githubusercontent.com/15721063/112840625-0da4e200-90fc-11eb-9185-1c7c21c91edf.png">
