### PR TITLE
feat(Table): Add custom row height examples to story (#925)

### DIFF
--- a/src/components/Table/component.stories.tsx
+++ b/src/components/Table/component.stories.tsx
@@ -71,6 +71,50 @@ export const Interactive = () => (
   </Card>
 );
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  > *:not(:last-child) {
+    margin-bottom: ${({ theme }) => em(theme.honeycomb.size.normal)};
+  }
+`;
+
+const StyledTableA = styled(Table)`
+  ${Table.TheadTr}, ${Table.TbodyTr} {
+    height: ${em(32)};
+  }
+`;
+
+const StyledTableB = styled(Table)`
+  ${Table.TheadTr}, ${Table.TbodyTr} {
+    height: ${em(72)};
+  }
+`;
+
+const StyledTableC = styled(Table)`
+  ${Table.TheadTr}, ${Table.TbodyTr} {
+    height: ${em(94)};
+  }
+`;
+
+export const CustomRowHeight = () => (
+  <Container>
+    <Card padding="none" shadow="increased">
+      <StyledTableA data={data.slice(0, 3)} columns={columns} />
+    </Card>
+    <Card padding="none" shadow="increased">
+      <Table data={data.slice(0, 3)} columns={columns} />
+    </Card>
+    <Card padding="none" shadow="increased">
+      <StyledTableB data={data.slice(0, 3)} columns={columns} />
+    </Card>
+    <Card padding="none" shadow="increased">
+      <StyledTableC data={data.slice(0, 3)} columns={columns} />
+    </Card>
+  </Container>
+);
+
 export const ControlledWithPagination: Story = () => {
   const [pageIndex, setPageIndex] = useState(5);
   const pageSize = 3;

--- a/src/components/Table/component.tsx
+++ b/src/components/Table/component.tsx
@@ -267,3 +267,7 @@ export const Component = <Data extends object>({
 Component.displayName = 'Table';
 
 Component.Sort = Sort;
+Component.Th = Th;
+Component.TheadTr = TheadTr;
+Component.TbodyTr = TbodyTr;
+Component.Td = Td;


### PR DESCRIPTION
Resolves [#925](https://github.com/binance-chain/ui-project-management/issues/925).

The row sizes from the UI design don't correspond with Honeycomb sizes, so we shouldn't add a `size` prop as it could get confusing. This PR just adds examples of custom row sizes to the `Table` story using `styled-components`, and exposes more inner components from `Table`.