### PR TITLE
feat(Accordion): UI optimisations for component, fix animations (#1047)

### DIFF
--- a/src/components/Accordion/PanelItem/component.tsx
+++ b/src/components/Accordion/PanelItem/component.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { HtmlTag } from '../../../modules/html-tag';
 import { Testable, useBuildTestId } from '../../../modules/test-ids';
 
 import { Content, Styled } from './styled';
@@ -8,7 +7,6 @@ import { Content, Styled } from './styled';
 export type Panel = {
   element: React.ReactNode;
   children?: React.ReactNode;
-  htmlTag?: HtmlTag;
 };
 
 export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as'> &
@@ -24,7 +22,6 @@ export const Component = ({
   children,
   activePanel,
   index,
-  htmlTag,
   onChange,
   onClick,
   'data-testid': testId,
@@ -65,14 +62,22 @@ export const Component = ({
     [onChange, onClick],
   );
 
+  const panel = useMemo(() => {
+    const it = element as React.ReactElement;
+    return (
+      <it.type
+        {...it.props}
+        onClick={(evt: React.MouseEvent<HTMLElement, MouseEvent>) => {
+          click(evt, index);
+          it.props.onClick?.();
+        }}
+      />
+    );
+  }, [click, element, index]);
+
   return (
-    <Styled
-      {...otherProps}
-      onClick={(evt: React.MouseEvent<HTMLElement, MouseEvent>) => click(evt, index)}
-      as={htmlTag as any}
-      data-testid={buildTestId()}
-    >
-      {element}
+    <Styled {...otherProps} data-testid={buildTestId()}>
+      {panel}
       {children && (
         <Content ref={contentRef} style={style} data-testid={buildTestId('children')}>
           {children}

--- a/src/components/Accordion/PanelItem/component.tsx
+++ b/src/components/Accordion/PanelItem/component.tsx
@@ -54,15 +54,13 @@ export const Component = ({
   );
 
   return (
-    <>
-      <Styled
-        {...otherProps}
-        onClick={(evt: React.MouseEvent<HTMLElement, MouseEvent>) => click(evt, index)}
-        as={htmlTag as any}
-        data-testid={buildTestId()}
-      >
-        {element}
-      </Styled>
+    <Styled
+      {...otherProps}
+      onClick={(evt: React.MouseEvent<HTMLElement, MouseEvent>) => click(evt, index)}
+      as={htmlTag as any}
+      data-testid={buildTestId()}
+    >
+      {element}
       {children &&
         boxTransitions.map(
           ({ item, key, props }) =>
@@ -72,7 +70,7 @@ export const Component = ({
               </animated.div>
             ),
         )}
-    </>
+    </Styled>
   );
 };
 

--- a/src/components/Accordion/PanelItem/styled.tsx
+++ b/src/components/Accordion/PanelItem/styled.tsx
@@ -1,3 +1,9 @@
 import styled from 'styled-components';
 
 export const Styled = styled.div``;
+
+export const Content = styled.div`
+  overflow hidden;
+  will-change height;
+  transition height ${({ theme }) => theme.honeycomb.duration.normal} ease-in-out;
+`;

--- a/src/components/Accordion/component.stories.tsx
+++ b/src/components/Accordion/component.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
+import { em } from 'polished';
 
 import { decorators } from '../../modules/decorators';
 import { Sections } from '../../modules/sections';
@@ -56,4 +57,46 @@ export const Default = () => {
       data-testid={'accordion'}
     />
   );
+};
+
+const StyledAccordion = styled(Accordion)`
+  ${Accordion.PanelItem} {
+    background: white;
+    margin-bottom: ${({ theme }) => em(theme.honeycomb.size.normal)};
+    border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal)};
+    overflow: hidden;
+  }
+`;
+
+const Element = styled.div`
+  background: #e0e0e0;
+  color: black;
+  padding: ${({ theme }) => em(theme.honeycomb.size.normal)};
+
+  :hover,
+  :active {
+    background: #eeeeee;
+  }
+`;
+
+const Child = styled.div`
+  font-size: ${({ theme }) => em(theme.honeycomb.size.small)};
+  padding: ${({ theme }) => em(theme.honeycomb.size.normal, theme.honeycomb.size.small)};
+`;
+
+export const CustomStyles = () => {
+  const [activePanel, setActivePanel] = useState(-1);
+
+  const changePanel = useCallback((index) => {
+    setActivePanel((prev) => (prev === index ? -1 : index));
+  }, []);
+
+  const panels: Panels = new Array(5).fill(null).map((_, index) => {
+    return {
+      element: <Element>Accordion {index + 1}</Element>,
+      children: <Child>Panel {index + 1}</Child>,
+    };
+  });
+
+  return <StyledAccordion panels={panels} activePanel={activePanel} onChange={changePanel} />;
 };

--- a/src/components/Accordion/component.stories.tsx
+++ b/src/components/Accordion/component.stories.tsx
@@ -18,8 +18,9 @@ export default {
 
 type Panels = React.ComponentPropsWithoutRef<typeof Accordion>['panels'];
 
-const StyledListItem = styled(ListItem)`
-  height: 2em;
+const Child = styled.div`
+  font-size: ${({ theme }) => em(theme.honeycomb.size.small)};
+  padding: ${({ theme }) => em(theme.honeycomb.size.normal, theme.honeycomb.size.small)};
 `;
 
 export const Default = () => {
@@ -45,7 +46,7 @@ export const Default = () => {
           Accordion {index + 1}
         </ListItem>
       ),
-      children: <StyledListItem data-testid={'child'}>Panel {index + 1}</StyledListItem>,
+      children: <Child data-testid={'child'}>Panel {index + 1}</Child>,
     };
   });
 
@@ -72,16 +73,12 @@ const Element = styled.div`
   background: #e0e0e0;
   color: black;
   padding: ${({ theme }) => em(theme.honeycomb.size.normal)};
+  cursor: pointer;
 
   :hover,
   :active {
     background: #eeeeee;
   }
-`;
-
-const Child = styled.div`
-  font-size: ${({ theme }) => em(theme.honeycomb.size.small)};
-  padding: ${({ theme }) => em(theme.honeycomb.size.normal, theme.honeycomb.size.small)};
 `;
 
 export const CustomStyles = () => {

--- a/src/components/Accordion/component.tsx
+++ b/src/components/Accordion/component.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Testable, useBuildTestId } from '../../modules/test-ids';
 
 import { Panel, PanelItem } from './PanelItem';
+import { Styled } from './PanelItem/styled';
 
 export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'children'> &
   Testable & {
@@ -37,3 +38,4 @@ export const Component = ({
 };
 
 Component.displayName = 'Accordion';
+Component.PanelItem = Styled;


### PR DESCRIPTION
Resolves [#1047](https://github.com/binance-chain/ui-project-management/issues/1047).

- Move panel item child inside parent so it's easier to style.
- Use CSS animations instead of `react-spring` for a smoother effect.
- Fix: clicking the panel item child should not close the parent.

![May-06-2021 00-03-54](https://user-images.githubusercontent.com/15721063/117138014-9ea76100-adfe-11eb-8ee0-b3ce20707f34.gif)

