### PR TITLE
feat(Table): Add `fixed` header style (#1077)

### DIFF
--- a/src/components/Table/component.stories.tsx
+++ b/src/components/Table/component.stories.tsx
@@ -18,6 +18,15 @@ export default {
   title: `${Sections.Elements}/Table`,
 };
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  > *:not(:last-child) {
+    margin-bottom: ${({ theme }) => em(theme.honeycomb.size.normal)};
+  }
+`;
+
 const Header = styled.div`
   display: flex;
   align-items: center;
@@ -125,49 +134,42 @@ export const Selectable = () => {
   );
 };
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
+export const CustomRowHeight = () => {
+  const StyledTableA = styled(Table)`
+    ${Table.TheadTr}, ${Table.TbodyTr} {
+      height: ${em(32)};
+    }
+  `;
 
-  > *:not(:last-child) {
-    margin-bottom: ${({ theme }) => em(theme.honeycomb.size.normal)};
-  }
-`;
+  const StyledTableB = styled(Table)`
+    ${Table.TheadTr}, ${Table.TbodyTr} {
+      height: ${em(72)};
+    }
+  `;
 
-const StyledTableA = styled(Table)`
-  ${Table.TheadTr}, ${Table.TbodyTr} {
-    height: ${em(32)};
-  }
-`;
+  const StyledTableC = styled(Table)`
+    ${Table.TheadTr}, ${Table.TbodyTr} {
+      height: ${em(94)};
+    }
+  `;
 
-const StyledTableB = styled(Table)`
-  ${Table.TheadTr}, ${Table.TbodyTr} {
-    height: ${em(72)};
-  }
-`;
-
-const StyledTableC = styled(Table)`
-  ${Table.TheadTr}, ${Table.TbodyTr} {
-    height: ${em(94)};
-  }
-`;
-
-export const CustomRowHeight = () => (
-  <Container>
-    <Card padding="none" shadow="increased">
-      <StyledTableA data={data.slice(0, 3)} columns={columns} />
-    </Card>
-    <Card padding="none" shadow="increased">
-      <Table data={data.slice(0, 3)} columns={columns} />
-    </Card>
-    <Card padding="none" shadow="increased">
-      <StyledTableB data={data.slice(0, 3)} columns={columns} />
-    </Card>
-    <Card padding="none" shadow="increased">
-      <StyledTableC data={data.slice(0, 3)} columns={columns} />
-    </Card>
-  </Container>
-);
+  return (
+    <Container>
+      <Card padding="none" shadow="increased">
+        <StyledTableA data={data.slice(0, 3)} columns={columns} />
+      </Card>
+      <Card padding="none" shadow="increased">
+        <Table data={data.slice(0, 3)} columns={columns} />
+      </Card>
+      <Card padding="none" shadow="increased">
+        <StyledTableB data={data.slice(0, 3)} columns={columns} />
+      </Card>
+      <Card padding="none" shadow="increased">
+        <StyledTableC data={data.slice(0, 3)} columns={columns} />
+      </Card>
+    </Container>
+  );
+};
 
 export const ControlledWithPagination: Story = () => {
   const [pageIndex, setPageIndex] = useState(5);
@@ -295,6 +297,8 @@ export const SortableWithDefaultSorting = () => {
             col2: (
               <Header>
                 <AbstractAvatar value="world" />
+                <Space size="small" />
+                World
               </Header>
             ),
           } as const),

--- a/src/components/Table/component.stories.tsx
+++ b/src/components/Table/component.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { em } from 'polished';
 import { action } from '@storybook/addon-actions';
 import { Story } from '@storybook/react/types-6-0';
@@ -69,11 +69,45 @@ export const Default = () => (
   </Card>
 );
 
-export const NoHeader = () => (
-  <Card padding="none" shadow="increased">
-    <Table data={data.slice(0, 10)} columns={columns} hasHeader={false} />
-  </Card>
-);
+export const HeaderStyles = () => {
+  const theme = useTheme();
+
+  const StyledContainer = styled(Container)`
+    height: calc(100vh - 2em);
+  `;
+
+  const FixedTableContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  `;
+
+  const StyledCard = styled(Card)`
+    display: flex;
+    flex-direction: column;
+  `;
+
+  return (
+    <StyledContainer>
+      <div>
+        <h3>no header</h3>
+        <Card padding="none" shadow="increased">
+          <Table data={data.slice(0, 3)} columns={columns} header={{ display: false }} />
+        </Card>
+      </div>
+      <FixedTableContainer>
+        <h3>fixed</h3>
+        <StyledCard padding="none" shadow="increased">
+          <Table
+            data={data.slice(0, 50)}
+            columns={columns}
+            header={{ fixed: true, background: theme.honeycomb.color.bg.normal }}
+          />
+        </StyledCard>
+      </FixedTableContainer>
+    </StyledContainer>
+  );
+};
 
 export const Interactive = () => (
   <Card padding="none" shadow="increased">

--- a/src/components/Table/component.tsx
+++ b/src/components/Table/component.tsx
@@ -39,7 +39,7 @@ export type Props<Data extends object> = Testable & {
   header?: {
     display?: boolean;
     fixed?: boolean;
-    background?: Property.Color;
+    background?: Property.Background;
   };
   pageIndex?: number;
   pageSize?: number;

--- a/src/components/Table/component.tsx
+++ b/src/components/Table/component.tsx
@@ -9,6 +9,7 @@ import {
   useSortBy,
   useTable,
 } from 'react-table';
+import { Property } from 'csstype';
 
 import { Testable, useBuildTestId } from '../../modules/test-ids';
 import { Button } from '../Button';
@@ -35,11 +36,15 @@ import {
 export type Props<Data extends object> = Testable & {
   data: TableOptions<Data>['data'];
   columns: TableOptions<Data>['columns'];
+  header?: {
+    display?: boolean;
+    fixed?: boolean;
+    background?: Property.Color;
+  };
   pageIndex?: number;
   pageSize?: number;
   pageCount?: number;
   hasPagination?: boolean;
-  hasHeader?: boolean;
   interactive?: boolean;
   className?: string;
   manualSortBy?: TableOptions<Data>['manualSortBy'];
@@ -52,10 +57,10 @@ export type Props<Data extends object> = Testable & {
 export const Component = <Data extends object>({
   data,
   columns,
+  header,
   pageIndex = 0,
   pageSize = 10,
   hasPagination = false,
-  hasHeader = true,
   interactive = false,
   className,
   manualSortBy,
@@ -117,6 +122,14 @@ export const Component = <Data extends object>({
     useSortBy,
     usePagination,
     useRowSelect,
+  );
+
+  const { isHeaderDisplayed, isHeaderFixed } = useMemo(
+    () => ({
+      isHeaderDisplayed: header?.display ?? true,
+      isHeaderFixed: header?.fixed ?? false,
+    }),
+    [header],
   );
 
   const filteredPageOptions = useMemo(
@@ -197,8 +210,8 @@ export const Component = <Data extends object>({
     <Container data-testid={buildTestId()}>
       <Scroll>
         <Table {...getTableProps()} className={className}>
-          {hasHeader && (
-            <Thead>
+          {isHeaderDisplayed && (
+            <Thead fixed={isHeaderFixed} background={header?.background}>
               {headerGroups.map((headerGroup) => (
                 <TheadTr {...headerGroup.getHeaderGroupProps()}>
                   {headerGroup.headers.map(getHeader)}

--- a/src/components/Table/styled.tsx
+++ b/src/components/Table/styled.tsx
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import { em } from 'polished';
+import { Property } from 'csstype';
 
 import { boxSizing } from '../../modules/box-sizing';
 import { Button } from '../Button';
@@ -10,24 +11,46 @@ const ROW_HEIGHT = 56;
 
 export const Container = styled.div`
   ${boxSizing};
-  display: block;
+  display: flex;
+  flex-direction: column;
   max-width: 100%;
+  overflow: hidden;
 `;
 
 export const Scroll = styled.div`
-  display: block;
+  display: flex;
+  flex-grow: 1;
   max-width: 100%;
-  overflow-x: auto;
-  overflow-y: hidden;
+  overflow: auto;
   scroll-behavior: smooth;
 `;
 
 export const Table = styled.table`
   width: 100%;
   border-spacing: 0;
+  z-index: ${({ theme }) => theme.honeycomb.zIndexes.normal};
 `;
 
-export const Thead = styled.thead``;
+interface HeaderProps {
+  fixed: boolean;
+  background?: Property.Color;
+}
+
+export const Thead = styled.thead<HeaderProps>`
+  ${({ fixed }) =>
+    fixed &&
+    css`
+      position: sticky;
+      top: 0;
+      z-index: ${({ theme }) => theme.honeycomb.zIndexes.normal + 2};
+    `};
+
+  ${({ background }) =>
+    background &&
+    css`
+      background: ${background};
+    `};
+`;
 
 export const TheadTr = styled.tr`
   height: ${em(ROW_HEIGHT)};

--- a/src/components/Table/styled.tsx
+++ b/src/components/Table/styled.tsx
@@ -33,7 +33,7 @@ export const Table = styled.table`
 
 interface HeaderProps {
   fixed: boolean;
-  background?: Property.Color;
+  background?: Property.Background;
 }
 
 export const Thead = styled.thead<HeaderProps>`

--- a/src/components/Table/styled.tsx
+++ b/src/components/Table/styled.tsx
@@ -8,6 +8,7 @@ import { hoverEffect } from '../HoverEffect';
 import { Icon } from '../Icon';
 
 const ROW_HEIGHT = 56;
+const ZINDEX_THEAD_FIXED = 2;
 
 export const Container = styled.div`
   ${boxSizing};
@@ -42,7 +43,7 @@ export const Thead = styled.thead<HeaderProps>`
     css`
       position: sticky;
       top: 0;
-      z-index: ${({ theme }) => theme.honeycomb.zIndexes.normal + 2};
+      z-index: ${({ theme }) => theme.honeycomb.zIndexes.normal + ZINDEX_THEAD_FIXED};
     `};
 
   ${({ background }) =>

--- a/src/components/Text/component.tsx
+++ b/src/components/Text/component.tsx
@@ -11,7 +11,7 @@ export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as' | 'size'> &
     htmlTag?: HtmlTag;
     alignItems?: Property.AlignItems;
     alignSelf?: Property.AlignSelf;
-    color?: string;
+    color?: Property.Color;
     size: Size;
     weight?: Weight;
   };


### PR DESCRIPTION
Resolves [#1077](https://github.com/binance-chain/ui-project-management/issues/1077).

- Add new `fixed` (or "sticky") header style to `<Table />`.
- **[Breaking Change]** Remove `hasHeader` prop, make one optional `header` prop.
```
header?: {
  display?: boolean; // hasHeader={false} -> header={{ display: false }}
  fixed?: boolean;
  background?: Property.Background; // Should set this if header={{ fixed: true }} otherwise scrolling tbody is visible.
};
```

<img width="500" src="https://user-images.githubusercontent.com/15721063/118122615-32081400-b447-11eb-80cc-05c3118c6882.gif" />

---

**Breaking Projects**
- [x] `landing-page`
- [x] `staking-ui`