### PR TITLE
fix(Table): `fixed` header does not work in Chrome (#1091)

### DIFF
--- a/src/components/Table/component.tsx
+++ b/src/components/Table/component.tsx
@@ -207,9 +207,9 @@ export const Component = <Data extends object>({
   );
 
   return (
-    <Container data-testid={buildTestId()}>
+    <Container data-testid={buildTestId()} className={className}>
       <Scroll>
-        <Table {...getTableProps()} className={className}>
+        <Table {...getTableProps()}>
           {isHeaderDisplayed && (
             <Thead fixed={isHeaderFixed} background={header?.background}>
               {headerGroups.map((headerGroup) => (
@@ -296,6 +296,8 @@ export const Component = <Data extends object>({
 
 Component.displayName = 'Table';
 
+Component.Scroll = Scroll;
+Component.Table = Table;
 Component.Sort = Sort;
 Component.Th = Th;
 Component.TheadTr = TheadTr;

--- a/src/components/Table/component.tsx
+++ b/src/components/Table/component.tsx
@@ -174,7 +174,12 @@ export const Component = <Data extends object>({
     (column: HeaderGroup<Data>) => {
       if (!column.defaultCanSort) {
         return (
-          <Th {...column.getHeaderProps()} data-testid={buildTestId(`${column.id}.th`)}>
+          <Th
+            {...column.getHeaderProps()}
+            fixed={isHeaderFixed}
+            background={header?.background}
+            data-testid={buildTestId(`${column.id}.th`)}
+          >
             {column.render('Header')}
           </Th>
         );
@@ -183,6 +188,8 @@ export const Component = <Data extends object>({
       return (
         <Th
           {...column.getHeaderProps(column.getSortByToggleProps())}
+          fixed={isHeaderFixed}
+          background={header?.background}
           data-testid={buildTestId(`${column.id}.th`)}
         >
           <SortWrapper>
@@ -203,7 +210,7 @@ export const Component = <Data extends object>({
         </Th>
       );
     },
-    [buildTestId],
+    [buildTestId, isHeaderFixed, header],
   );
 
   return (
@@ -211,7 +218,7 @@ export const Component = <Data extends object>({
       <Scroll>
         <Table {...getTableProps()}>
           {isHeaderDisplayed && (
-            <Thead fixed={isHeaderFixed} background={header?.background}>
+            <Thead>
               {headerGroups.map((headerGroup) => (
                 <TheadTr {...headerGroup.getHeaderGroupProps()}>
                   {headerGroup.headers.map(getHeader)}

--- a/src/components/Table/styled.tsx
+++ b/src/components/Table/styled.tsx
@@ -32,12 +32,25 @@ export const Table = styled.table`
   z-index: ${({ theme }) => theme.honeycomb.zIndexes.normal};
 `;
 
-interface HeaderProps {
+export const Thead = styled.thead``;
+
+export const TheadTr = styled.tr`
+  height: ${em(ROW_HEIGHT)};
+`;
+
+export interface ThProps {
   fixed: boolean;
   background?: Property.Background;
 }
 
-export const Thead = styled.thead<HeaderProps>`
+export const Th = styled.th<ThProps>`
+  border-bottom: 1px solid ${({ theme }) => theme.honeycomb.color.border};
+  text-align: left;
+  padding: 0 ${({ theme }) => em(theme.honeycomb.size.increased, theme.honeycomb.size.small)};
+  font-size: ${({ theme }) => em(theme.honeycomb.size.small)};
+  color: ${({ theme }) => theme.honeycomb.color.text.masked};
+  font-weight: 400;
+
   ${({ fixed }) =>
     fixed &&
     css`
@@ -51,19 +64,6 @@ export const Thead = styled.thead<HeaderProps>`
     css`
       background: ${background};
     `};
-`;
-
-export const TheadTr = styled.tr`
-  height: ${em(ROW_HEIGHT)};
-`;
-
-export const Th = styled.th`
-  border-bottom: 1px solid ${({ theme }) => theme.honeycomb.color.border};
-  text-align: left;
-  padding: 0 ${({ theme }) => em(theme.honeycomb.size.increased, theme.honeycomb.size.small)};
-  font-size: ${({ theme }) => em(theme.honeycomb.size.small)};
-  color: ${({ theme }) => theme.honeycomb.color.text.masked};
-  font-weight: 400;
 `;
 
 export const Td = styled.td`
@@ -89,7 +89,7 @@ export const SortWrapper = styled.div`
   align-items: center;
 `;
 
-interface SortProps {
+export interface SortProps {
   selected: boolean;
 }
 


### PR DESCRIPTION
Resolves [#1091](https://github.com/binance-chain/ui-project-management/issues/1091).

The issue is that `position: sticky` does not work in Chrome (latest version at the time of writing) when applied to `thead`. Also does not work in Edge. ([reference](https://caniuse.com/css-sticky))

This PR moves the sticky styles to the `th` element, which is supported.

Also expose more inner elements, like `Scroll` and the outermost container, to support more customisation.
```
const StyledTable = styled(Table)`
  height: 100px; // Applied to outermost container.

  ${Table.Scroll} {
    // Applied to scroll container.
  }

  ${Table.Table} {
    // Applied to the actual `table` element.
  }
`;
```

This does not break any existing projects.