### PR TITLE
fix(CryptoAddress): Stop `wrap` prop from being passed to the DOM element

### DIFF
--- a/src/components/CryptoAddress/component.tsx
+++ b/src/components/CryptoAddress/component.tsx
@@ -66,11 +66,11 @@ export const Component = ({
   );
 
   return (
-    <Container className={className} wrap={wrap} data-testid={buildTestId()}>
+    <Container className={className} $wrap={wrap} data-testid={buildTestId()}>
       <CryptoAddress size={size} data-testid={buildTestId('address')}>
         {text || value}
       </CryptoAddress>
-      <ButtonWrapper wrap={wrap}>
+      <ButtonWrapper $wrap={wrap}>
         {canScanQrCode && (
           <>
             {isSm ? (

--- a/src/components/CryptoAddress/styled.tsx
+++ b/src/components/CryptoAddress/styled.tsx
@@ -25,11 +25,11 @@ const huge = css`
   padding-right: ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
 `;
 
-export const Container = styled.div<{ wrap: boolean }>`
+export const Container = styled.div<{ $wrap: boolean }>`
   display: flex;
   align-items: center;
 
-  ${({ wrap }) =>
+  ${({ $wrap: wrap }) =>
     wrap &&
     css`
       flex-wrap: wrap;
@@ -46,10 +46,10 @@ export const CryptoAddress = styled.div<{ size: Size }>`
   ${({ size }) => size === 'huge' && huge};
 `;
 
-export const ButtonWrapper = styled.div<{ wrap: boolean }>`
+export const ButtonWrapper = styled.div<{ $wrap: boolean }>`
   display: flex;
 
-  ${({ wrap }) =>
+  ${({ $wrap: wrap }) =>
     wrap &&
     css`
       flex-basis: 100%;


### PR DESCRIPTION
Fixes the error:

Warning: Received `false` for a non-boolean attribute `wrap`.

If you want to write it to the DOM, pass a string instead: wrap="false" or wrap={value.toString()}.