### PR TITLE
feat: Several component optimisations (#1238)

### DIFF
--- a/src/components/CryptoAddress/component.stories.tsx
+++ b/src/components/CryptoAddress/component.stories.tsx
@@ -7,7 +7,7 @@ import { Sections } from '../../modules/sections';
 
 import { SIZES } from './styled';
 
-import { CryptoAddress } from './';
+import { CryptoAddress } from '.';
 
 export default {
   component: CryptoAddress,

--- a/src/components/CryptoAddress/component.tsx
+++ b/src/components/CryptoAddress/component.tsx
@@ -33,7 +33,7 @@ export const Component = ({
   className,
   canCopyToClipboard = true,
   canScanQrCode = true,
-  size = 'increased',
+  size = 'huge',
   wrap = false,
   'data-testid': testId,
 }: Props) => {

--- a/src/components/Dropdown/DefaultTarget/component.tsx
+++ b/src/components/Dropdown/DefaultTarget/component.tsx
@@ -1,21 +1,26 @@
 import React, { useContext } from 'react';
 
 import { Context } from '../context';
+import { Shape, Size } from '../../internal/DefaultTarget';
 import { Styleless } from '../../Styleless';
 
 import { Icon } from './Icon';
 import { StyledDefaultTarget } from './styled';
 
-export type Props = React.ComponentPropsWithoutRef<typeof Styleless> & {
+export type Props = Omit<React.ComponentPropsWithoutRef<typeof Styleless>, 'size'> & {
   children: React.ReactNode;
   arrow?: boolean;
   highlightWhenOpen?: boolean;
+  shape?: Shape;
+  size?: Size;
 };
 
 export const Component = ({
   htmlTag = 'button',
   arrow = true,
   highlightWhenOpen = false,
+  shape = 'fill',
+  size = 'huge',
   ...otherProps
 }: Partial<Props>) => {
   const { isShowing } = useContext(Context);
@@ -26,6 +31,8 @@ export const Component = ({
       as={htmlTag as any}
       highlightWhenOpen={highlightWhenOpen}
       isShowing={isShowing}
+      shape={shape}
+      size={size}
     >
       {otherProps.children}
       {arrow && <Icon open={isShowing} />}

--- a/src/components/Dropdown/component.stories.tsx
+++ b/src/components/Dropdown/component.stories.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
+import { em } from 'polished';
 
 import { decorators } from '../../modules/decorators';
 import { Sections } from '../../modules/sections';
 import { GoldLight } from '../../modules/themes/themes/GoldLight';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
+import { SHAPES, SIZES } from '../internal/DefaultTarget';
 
 import { Dropdown } from '.';
 
@@ -94,5 +97,29 @@ export const Selectable = () => {
         </Dropdown.Item>
       ))}
     </Dropdown>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  > *:not(:last-child) {
+    margin-bottom: ${({ theme }) => em(theme.honeycomb.size.normal)};
+  }
+`;
+
+export const TargetVariants = () => {
+  return (
+    <Container>
+      <h3>size</h3>
+      {SIZES.map((size) => (
+        <Dropdown.DefaultTarget size={size}>{size}</Dropdown.DefaultTarget>
+      ))}
+      <h3>shape</h3>
+      {SHAPES.map((shape) => (
+        <Dropdown.DefaultTarget shape={shape}>{shape}</Dropdown.DefaultTarget>
+      ))}
+    </Container>
   );
 };

--- a/src/components/Header/styled.tsx
+++ b/src/components/Header/styled.tsx
@@ -81,6 +81,7 @@ export const Item = styled(ListItem)<{ isMenu?: boolean }>`
 
 export const StyledDropdownDefaultTarget = styled(Dropdown.DefaultTarget)`
   ${headerItem};
+  padding: 0;
 `;
 
 export const StyledDropdownItem = styled(Dropdown.Item)`

--- a/src/components/SegmentedControl/styled.tsx
+++ b/src/components/SegmentedControl/styled.tsx
@@ -60,11 +60,12 @@ export const Element = styled.li<ElementProps>`
   ${({ variant }) =>
     variant === 'tab' &&
     css`
-      border-bottom: 2px solid transparent;
+      border-bottom: 1px solid ${({ theme }) => theme.honeycomb.color.border};
       border-radius: 0;
+      color: ${({ theme }) =>theme.honeycomb.color.text.masked};
     `};
 
-  ${({ theme }) => transitions(['background', 'color'], theme.honeycomb.duration.normal)};
+  ${({ theme }) => transitions(['background', 'border', 'color'], theme.honeycomb.duration.normal)};
   ${({ active }) => active && activeElement}
 `;
 
@@ -101,7 +102,6 @@ export const Container = styled.ul<ContainerProps>`
       `) ||
     (variant === 'tab' &&
       css`
-        border-bottom: 1px solid ${({ theme }) => theme.honeycomb.color.border};
         border-radius: 0;
       `)};
 `;

--- a/src/components/SegmentedControl/styled.tsx
+++ b/src/components/SegmentedControl/styled.tsx
@@ -62,7 +62,7 @@ export const Element = styled.li<ElementProps>`
     css`
       border-bottom: 1px solid ${({ theme }) => theme.honeycomb.color.border};
       border-radius: 0;
-      color: ${({ theme }) =>theme.honeycomb.color.text.masked};
+      color: ${({ theme }) => theme.honeycomb.color.text.masked};
     `};
 
   ${({ theme }) => transitions(['background', 'border', 'color'], theme.honeycomb.duration.normal)};

--- a/src/components/Select/DefaultTarget/component.tsx
+++ b/src/components/Select/DefaultTarget/component.tsx
@@ -2,18 +2,29 @@ import React, { useContext, useMemo } from 'react';
 
 import { Testable, useBuildTestId } from '../../../modules/test-ids';
 import { Icon } from '../../Icon';
-import { DefaultTarget } from '../../internal/DefaultTarget';
+import { DefaultTarget, Shape, Size } from '../../internal/DefaultTarget';
 import { ListItem } from '../../ListItem';
 import { Context } from '../context';
 import { useCurrentVariant } from '../useCurrentVariant';
 
 import { StyledListItem } from './styled';
 
-export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as'> &
+export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as' | 'size'> &
   Pick<React.ComponentPropsWithoutRef<typeof ListItem>, 'children' | 'left' | 'onClick'> &
-  Testable;
+  Testable & {
+    shape?: Shape;
+    size?: Size;
+  };
 
-export const Component = ({ children, onClick, 'data-testid': testId, ...otherProps }: Props) => {
+export const Component = ({
+  children,
+  className,
+  onClick,
+  shape = 'fill',
+  size = 'huge',
+  'data-testid': testId,
+  ...otherProps
+}: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
   const { variant = 'responsive', isShowing } = useContext(Context);
   const currentVariant = useCurrentVariant({ variant });
@@ -31,14 +42,14 @@ export const Component = ({ children, onClick, 'data-testid': testId, ...otherPr
   }, [isShowing, currentVariant, buildTestId]);
 
   return (
-    <DefaultTarget>
+    <DefaultTarget shape={shape} size={size} className={className} data-testid={buildTestId()}>
       <StyledListItem
+        htmlTag="div"
         right={right}
         showBorder={false}
         interactive={false}
         onClick={onClick}
         {...otherProps}
-        data-testid={buildTestId()}
       >
         {children}
       </StyledListItem>

--- a/src/components/Select/DefaultTarget/styled.tsx
+++ b/src/components/Select/DefaultTarget/styled.tsx
@@ -5,6 +5,7 @@ import { ListItem } from '../../ListItem';
 
 export const StyledListItem = styled(ListItem)`
   height: 100%;
+  padding: 0;
 
   ${ListItem.Right} {
     font-size: ${({ theme }) => em(10, theme.honeycomb.size.reduced)};

--- a/src/components/Select/component.stories.tsx
+++ b/src/components/Select/component.stories.tsx
@@ -1,16 +1,18 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { em } from 'polished';
 
 import { decorators } from '../../modules/decorators';
 import { Sections } from '../../modules/sections';
 import { Card } from '../Card';
 import { Icon } from '../Icon';
+import { SHAPES, SIZES } from '../internal/DefaultTarget';
 import { ListItem } from '../ListItem';
 
 // @ts-ignore
 import pic from './pic.png';
 
-import { Select } from './';
+import { Select } from '.';
 
 export default {
   component: Select,
@@ -237,3 +239,28 @@ export const WithSearchPlaceholder = () => {
     </>
   );
 };
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  > *:not(:last-child) {
+    margin-bottom: ${({ theme }) => em(theme.honeycomb.size.normal)};
+  }
+`;
+
+export const TargetVariants = () => {
+  return (
+    <Container>
+      <h3>size</h3>
+      {SIZES.map((size) => (
+        <Select.DefaultTarget size={size}>{size}</Select.DefaultTarget>
+      ))}
+      <h3>shape</h3>
+      {SHAPES.map((shape) => (
+        <Select.DefaultTarget shape={shape}>{shape}</Select.DefaultTarget>
+      ))}
+    </Container>
+  );
+};
+TargetVariants.decorators = decorators;

--- a/src/components/TextInput/component.stories.tsx
+++ b/src/components/TextInput/component.stories.tsx
@@ -39,9 +39,7 @@ export const WithLabel = () => (
   <TextInput placeholder="Some placeholder" label="A label" value="" />
 );
 
-export const WithDescription = () => (
-  <TextInput description="Some description." value="" />
-);
+export const WithDescription = () => <TextInput description="Some description." value="" />;
 
 export const WithPlaceholder = () => <TextInput placeholder="Some placeholder" value="" />;
 

--- a/src/components/TextInput/component.stories.tsx
+++ b/src/components/TextInput/component.stories.tsx
@@ -26,29 +26,29 @@ const Container = styled.div`
 `;
 
 export const Text = () => {
-  const [value, setValue] = useState('Some text…');
+  const [value, setValue] = useState('Some text...');
   return <TextInput value={value} onChange={(evt) => setValue(evt.target.value)} />;
 };
 
 export const InvalidText = () => {
-  const [value, setValue] = useState('Invalid text…');
+  const [value, setValue] = useState('Invalid text');
   return <TextInput state="danger" value={value} onChange={(evt) => setValue(evt.target.value)} />;
 };
 
 export const WithLabel = () => (
-  <TextInput placeholder="Some placeholder…" label="A label" value="" />
+  <TextInput placeholder="Some placeholder" label="A label" value="" />
 );
 
 export const WithDescription = () => (
-  <TextInput placeholder="Some placeholder…" label="A label" value="" />
+  <TextInput description="Some description." value="" />
 );
 
-export const WithPlaceholder = () => <TextInput placeholder="Some placeholder…" value="" />;
+export const WithPlaceholder = () => <TextInput placeholder="Some placeholder" value="" />;
 
 export const WithLeftAndRightAppendixes = () => (
   <TextInput
     label="Amount"
-    placeholder="Some placeholder…"
+    placeholder="Some placeholder"
     value=""
     left={<div>€</div>}
     right={
@@ -76,7 +76,7 @@ export const WithEnd = () => {
             </Button>
           </>
         }
-        description="Some description..."
+        description="Some description."
       />
       <TextInput
         label="With End and Left/Right Appendixes"
@@ -170,14 +170,14 @@ const CustomTextInput = styled(TextInput)`
 export const CustomStyles = () => (
   <>
     <CustomTextInput
-      placeholder="Some placeholder…"
+      placeholder="Some placeholder"
       label="A label"
       value="10"
       right="gwei"
       size="increased"
     />
     <CustomTextInput
-      placeholder="Some placeholder…"
+      placeholder="Some placeholder"
       label="A label"
       value="215510"
       size="increased"

--- a/src/components/TextInput/component.tsx
+++ b/src/components/TextInput/component.tsx
@@ -181,9 +181,17 @@ export const Component = ({
         $scale={scale}
         hasEnd={!!end}
       >
-        {left && <Left size={size} data-testid={buildTestId('left')}>{left}</Left>}
+        {left && (
+          <Left size={size} data-testid={buildTestId('left')}>
+            {left}
+          </Left>
+        )}
         {input}
-        {right && <Right size={size} data-testid={buildTestId('right')}>{right}</Right>}
+        {right && (
+          <Right size={size} data-testid={buildTestId('right')}>
+            {right}
+          </Right>
+        )}
       </InputContainer>
     );
 

--- a/src/components/TextInput/component.tsx
+++ b/src/components/TextInput/component.tsx
@@ -181,9 +181,9 @@ export const Component = ({
         $scale={scale}
         hasEnd={!!end}
       >
-        {left && <Left data-testid={buildTestId('left')}>{left}</Left>}
+        {left && <Left size={size} data-testid={buildTestId('left')}>{left}</Left>}
         {input}
-        {right && <Right data-testid={buildTestId('right')}>{right}</Right>}
+        {right && <Right size={size} data-testid={buildTestId('right')}>{right}</Right>}
       </InputContainer>
     );
 

--- a/src/components/TextInput/styled.tsx
+++ b/src/components/TextInput/styled.tsx
@@ -129,7 +129,7 @@ export const Input = styled.div<InputProps>`
   ${({ theme }) => transitions(['color'], `${theme.honeycomb.duration.normal} ease-in-out`)};
 
   ::placeholder {
-    color: ${({ theme }) => theme.honeycomb.color.text.masked};
+    color: ${({ theme }) => theme.honeycomb.color.text.disabled};
   }
 
   ${({ size }) =>

--- a/src/components/TextInput/styled.tsx
+++ b/src/components/TextInput/styled.tsx
@@ -169,14 +169,16 @@ export const Left = styled.div<Pick<InputProps, 'size'>>`
   display: flex;
   align-items: stretch;
   justify-content: stretch;
-  margin-right: ${({ theme, size }) => em(marginSize({ theme, size }), theme.honeycomb.size.reduced)};
+  margin-right: ${({ theme, size }) =>
+    em(marginSize({ theme, size }), theme.honeycomb.size.reduced)};
 `;
 
 export const Right = styled.div<Pick<InputProps, 'size'>>`
   display: flex;
   align-items: stretch;
   justify-content: stretch;
-  margin-left: ${({ theme, size }) => em(marginSize({ theme, size }), theme.honeycomb.size.reduced)};
+  margin-left: ${({ theme, size }) =>
+    em(marginSize({ theme, size }), theme.honeycomb.size.reduced)};
 `;
 
 export const End = styled.div`

--- a/src/components/TextInput/styled.tsx
+++ b/src/components/TextInput/styled.tsx
@@ -159,18 +159,24 @@ export const Input = styled.div<InputProps>`
     `};
 `;
 
-export const Left = styled.div`
+const marginSize = ({ theme, size }: { theme: DefaultTheme; size: Size }) => {
+  return size === 'normal' || size === 'increased'
+    ? theme.honeycomb.size.micro
+    : theme.honeycomb.size.small;
+};
+
+export const Left = styled.div<Pick<InputProps, 'size'>>`
   display: flex;
   align-items: stretch;
   justify-content: stretch;
-  margin-right: ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
+  margin-right: ${({ theme, size }) => em(marginSize({ theme, size }), theme.honeycomb.size.reduced)};
 `;
 
-export const Right = styled.div`
+export const Right = styled.div<Pick<InputProps, 'size'>>`
   display: flex;
   align-items: stretch;
   justify-content: stretch;
-  margin-left: ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
+  margin-left: ${({ theme, size }) => em(marginSize({ theme, size }), theme.honeycomb.size.reduced)};
 `;
 
 export const End = styled.div`

--- a/src/components/internal/DefaultTarget/index.tsx
+++ b/src/components/internal/DefaultTarget/index.tsx
@@ -3,16 +3,26 @@ import { transitions, em } from 'polished';
 
 import { styleless } from '../../Styleless';
 import { boxSizing } from '../../../modules/box-sizing';
+import { fontSize, huge, increased } from '../Size';
+import { fill, fit } from '../Shape';
 
-export const DefaultTarget = styled.div`
+export const SHAPES = ['fill', 'fit'] as const;
+export type Shape = typeof SHAPES[number];
+
+export const SIZES = ['increased', 'huge'] as const;
+export type Size = typeof SIZES[number];
+
+export const DefaultTarget = styled.div<{ shape: Shape; size: Size }>`
   ${styleless};
   ${boxSizing};
 
-  width: 100%;
   background: ${({ theme }) => theme.honeycomb.color.bg.input.normal};
-  font-size: ${({ theme }) => em(theme.honeycomb.size.reduced)};
-  border-radius: ${({ theme }) => em(theme.honeycomb.radius.normal, theme.honeycomb.size.reduced)};
-  height: ${({ theme }) => em(theme.honeycomb.size.huge, theme.honeycomb.size.reduced)};
-  cursor: pointer;
   ${({ theme }) => transitions(['background', 'color'], theme.honeycomb.duration.normal)};
+
+  ${({ shape }) => shape === 'fill' && fill};
+  ${({ shape }) => shape === 'fit' && fit};
+
+  font-size: ${({ theme, size }) => em(fontSize({ theme, size }))};
+  ${({ size }) => size === 'increased' && increased};
+  ${({ size }) => size === 'huge' && huge};
 `;


### PR DESCRIPTION
Resolves [#1238](https://github.com/binance-chain/ui-project-management/issues/1238).

-  `TextInput`: Change placeholder text colour, reduce margin size of left/right elements for size="normal | increased"`.
- `SegmentedControl`: Change non-selected text colour, add transition for border.
- `Dropdown.DefaultTarget`, `Select.DefaultTarget`: Add `size` and `shape` props.
- `CryptoAddress`: Change default size to `huge` to match other components.

**Breaking Changes**
- `CryptoAddress` usage in staking and extension wallet.