### PR TITLE
feat(Button): Add outlined styles (#1283)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,7 @@
     "public": true,
     "storybook-static": true
   },
-  "typescript.preferences.importModuleSpecifier": "relative"
+  "typescript.preferences.importModuleSpecifier": "relative",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
 }

--- a/src/components/Button/component.stories.tsx
+++ b/src/components/Button/component.stories.tsx
@@ -117,17 +117,25 @@ export const AsAnchor = () => (
 export const WithIconAndText = () => (
   <Container>
     {VARIANTS.map((variant) => (
-      <Container>
-        <Button
-          href="https://binance.org"
-          onClick={action('clicked')}
-          key={`${variant}`}
-          variant={variant}
-          icon={<Icon.BinanceChain />}
-        >
-          A button
-        </Button>
-      </Container>
+      <Button
+        href="https://binance.org"
+        onClick={action('clicked')}
+        key={`${variant}`}
+        variant={variant}
+        icon={<Icon.BinanceChain />}
+      >
+        A button
+      </Button>
+    ))}
+  </Container>
+);
+
+export const Outlined = () => (
+  <Container>
+    {VARIANTS.map((variant) => (
+      <Button key={`${variant}-outlined`} variant={variant} outlined>
+        An outlined {variant} button
+      </Button>
     ))}
   </Container>
 );

--- a/src/components/Button/component.tsx
+++ b/src/components/Button/component.tsx
@@ -16,6 +16,7 @@ export type Props = Omit<React.AllHTMLAttributes<HTMLElement>, 'as' | 'size'> &
     size?: Size;
     shape?: Shape;
     icon?: React.ReactNode;
+    outlined?: boolean;
   };
 
 export const Component = ({
@@ -31,6 +32,7 @@ export const Component = ({
   variant,
   size = 'huge',
   shape = 'fill',
+  outlined,
   ...otherProps
 }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
@@ -65,6 +67,7 @@ export const Component = ({
       variant={variant}
       size={size}
       $shape={shape}
+      outlined={outlined}
       onClick={click}
     >
       {icon && (

--- a/src/components/Button/styled.tsx
+++ b/src/components/Button/styled.tsx
@@ -1,5 +1,6 @@
-import styled, { css } from 'styled-components';
+import styled, { css, DefaultTheme } from 'styled-components';
 import { em, transitions } from 'polished';
+import { Property } from 'csstype';
 
 import { Shape, fill, fit, square } from '../internal/Shape';
 import { Size, normal, increased, huge, giant, fontSize } from '../internal/Size';
@@ -23,6 +24,7 @@ export interface Props {
   size: Size;
   $shape: Shape;
   disabled?: boolean;
+  outlined?: boolean;
 }
 
 export const Shadow = styled.div`
@@ -158,6 +160,75 @@ const link = css`
   }
 `;
 
+export const outlineColor = ({
+  theme,
+  variant,
+}: {
+  theme: DefaultTheme;
+  variant: Variant;
+}): {
+  normal: Property.Color;
+  active: Property.Color;
+} => {
+  switch (variant) {
+    case 'transparent':
+      return {
+        normal: theme.honeycomb.color.text.normal,
+        active: theme.honeycomb.color.primary.normal,
+      };
+    case 'primary':
+      return {
+        normal: theme.honeycomb.color.primary.normal,
+        active: theme.honeycomb.color.primary.active,
+      };
+    case 'secondary':
+      return {
+        normal: theme.honeycomb.color.secondary.normal,
+        active: theme.honeycomb.color.secondary.active,
+      };
+    case 'success':
+      return {
+        normal: theme.honeycomb.color.success.normal,
+        active: theme.honeycomb.color.success.active,
+      };
+    case 'danger':
+      return {
+        normal: theme.honeycomb.color.danger.normal,
+        active: theme.honeycomb.color.danger.active,
+      };
+    case 'buy':
+      return {
+        normal: theme.honeycomb.color.success.normal,
+        active: theme.honeycomb.color.success.active,
+      };
+    case 'sell':
+      return {
+        normal: theme.honeycomb.color.danger.normal,
+        active: theme.honeycomb.color.danger.active,
+      };
+    case 'link':
+      return {
+        normal: theme.honeycomb.color.primary.normal,
+        active: theme.honeycomb.color.primary.active,
+      };
+  }
+};
+
+export const outlined = css<{ variant: Variant }>`
+  border: 1px solid ${({ theme, variant }) => outlineColor({ theme, variant }).normal};
+  color: ${({ theme, variant }) => outlineColor({ theme, variant }).normal};
+  background: transparent;
+
+  :hover,
+  :active,
+  :focus,
+  :focus-within {
+    border-color: ${({ theme, variant }) => outlineColor({ theme, variant }).active};
+    color: ${({ theme, variant }) => outlineColor({ theme, variant }).active};
+    background: transparent;
+  }
+`;
+
 export const Styled = styled.button<Props>`
   ${stylelessCommon};
   ${boxSizing};
@@ -192,6 +263,8 @@ export const Styled = styled.button<Props>`
   ${({ variant }) => variant === 'primary' && primary};
   ${({ variant }) => variant === 'transparent' && transparent};
   ${({ variant }) => variant === 'link' && link};
+
+  ${({ outlined: isOutlined }) => isOutlined && outlined};
 
   font-size: ${({ theme, size }) => em(fontSize({ theme, size }))};
   ${({ size }) => size === 'normal' && normal};


### PR DESCRIPTION
Resolves [#1283](https://github.com/binance-chain/ui-project-management/issues/1283).

- Add optional `outlined` prop.
- Respect colour and styles from `variant` prop.

<img width="360" alt="image" src="https://user-images.githubusercontent.com/15721063/126978508-0e9a8860-5ab8-41c3-b59b-101cc4f29018.png">
