### PR TITLE
fix(Dropdown, Select): Stop propagation when closed on background click (#1328)

### DIFF
--- a/cypress/integration/Modal.ts
+++ b/cypress/integration/Modal.ts
@@ -29,11 +29,11 @@ describe('Modal', () => {
     cy.get('[data-testid="modal-inner"]').should('be.visible');
 
     cy.get('[data-testid="dropdown.target"]').click();
-    new Array(5).fill(null).forEach((_, index) => {
-      cy.get(`[data-testid="dropdown.${index}"]`).should('be.visible');
-    });
+    cy.get('[data-testid="dropdown.option"]').should('be.visible');
+    cy.get('body').click(0, 0);
+    cy.get('[data-testid="dropdown.option"]').should('not.exist');
 
-    cy.get('[data-testid="modal-inner.header.close-btn"]').click();
+    cy.get('[data-testid="modal-inner"]').type('{esc}');
     cy.get('[data-testid="modal-outer"]').should('be.visible');
     cy.get('[data-testid="modal-inner"]').should('not.exist');
 

--- a/cypress/integration/Select.ts
+++ b/cypress/integration/Select.ts
@@ -31,7 +31,9 @@ describe('Select', () => {
     cy.get('[data-testid="dark.select.modal.content"]').should('not.exist');
     cy.get('[data-testid="dark.select.dropdown.content"]').should('be.visible');
 
-    cy.percySnapshot('Select with Gold Dark theme while open on a large screen', { widths: [1280] });
+    cy.percySnapshot('Select with Gold Dark theme while open on a large screen', {
+      widths: [1280],
+    });
   });
 
   it('search input not rendered when children are not filterable', () => {
@@ -55,21 +57,21 @@ describe('Select', () => {
     cy.get('[data-testid="light.select.default-target"]').click();
     cy.tick(10000);
 
-    cy.get('[data-testid="light.select.0"]').should('be.visible');
-    cy.get('[data-testid="light.select.1"]').should('be.visible');
-    cy.get('[data-testid="light.select.2"]').should('be.visible');
+    cy.get('[data-testid="light.select.dropdown.0"]').should('be.visible');
+    cy.get('[data-testid="light.select.dropdown.1"]').should('be.visible');
+    cy.get('[data-testid="light.select.dropdown.2"]').should('be.visible');
 
-    cy.get('[data-testid="light.select.0"]').click();
+    cy.get('[data-testid="light.select.dropdown.0"]').click();
     cy.tick(10000);
 
-    cy.get('[data-testid="light.select.content"]').should('not.exist');
+    cy.get('[data-testid="light.select.dropdown.content"]').should('not.exist');
 
     cy.get('[data-testid="light.select.default-target"]').click();
     cy.tick(10000);
 
-    cy.get('[data-testid="light.select.0.tick"]').should('be.visible');
-    cy.get('[data-testid="light.select.1.tick"]').should('not.exist');
-    cy.get('[data-testid="light.select.2.tick"]').should('not.exist');
+    cy.get('[data-testid="light.select.dropdown.0.tick"]').should('be.visible');
+    cy.get('[data-testid="light.select.dropdown.1.tick"]').should('not.exist');
+    cy.get('[data-testid="light.select.dropdown.2.tick"]').should('not.exist');
 
     cy.percySnapshot('Select variant="dropdown"');
   });

--- a/src/components/Dropdown/Item/component.tsx
+++ b/src/components/Dropdown/Item/component.tsx
@@ -24,14 +24,14 @@ export const Component = ({
   });
   const { onClose } = useContext(Context);
 
-  const click = useCallback<NonNullable<Props['onClick']>>(
+  const click = useCallback(
     (evt) => {
       try {
         onClick?.(evt);
       } catch (e) {
         throw e;
       } finally {
-        onClose?.();
+        onClose?.(evt);
       }
     },
     [onClick, onClose],

--- a/src/components/Dropdown/component.tsx
+++ b/src/components/Dropdown/component.tsx
@@ -29,10 +29,14 @@ export const Component = ({
   const [isShowing, setIsShowing] = useState(false);
   const { buildTestId } = useBuildTestId({ id: testId });
 
-  const click = useCallback<NonNullable<Props['onClick']>>(() => {
-    setIsShowing((value) => !value);
-    onClick?.();
-  }, [onClick]);
+  const click = useCallback(
+    (evt) => {
+      evt.stopPropagation();
+      setIsShowing((value) => !value);
+      onClick?.();
+    },
+    [onClick],
+  );
 
   const content = useMemo(() => {
     if (bare) {
@@ -54,7 +58,7 @@ export const Component = ({
             {content}
           </ContentContext.Provider>
         }
-        onClickOutside={click}
+        onClickOutside={(_, evt) => click(evt)}
         bare={bare}
         padding="none"
         radius={radius}

--- a/src/components/Dropdown/context.tsx
+++ b/src/components/Dropdown/context.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const Context = React.createContext<{ isShowing: boolean; onClose?: () => void }>({
+export const Context = React.createContext<{ isShowing: boolean; onClose?: (evt: Event) => void }>({
   isShowing: false,
 });
 export const ContentContext = React.createContext<{ testId?: string }>({});

--- a/src/components/Modal/component.tsx
+++ b/src/components/Modal/component.tsx
@@ -48,7 +48,7 @@ export const Component = ({
   loading,
   position = 'center',
   closeOnEsc = true,
-  closeOnBackgroundClick = false,
+  closeOnBackgroundClick = true,
   onClose,
   'data-testid': testId,
 }: Props) => {

--- a/src/components/Select/DefaultTarget/component.tsx
+++ b/src/components/Select/DefaultTarget/component.tsx
@@ -26,7 +26,7 @@ export const Component = ({
   ...otherProps
 }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
-  const { variant = 'responsive', isShowing } = useContext(Context);
+  const { variant, isShowing } = useContext(Context);
   const currentVariant = useCurrentVariant({ variant });
 
   const right = useMemo(() => {

--- a/src/components/Select/Option/component.tsx
+++ b/src/components/Select/Option/component.tsx
@@ -4,7 +4,7 @@ import { useBuildTestId } from '../../../modules/test-ids';
 import { ListItem } from '../../ListItem';
 import { Context } from '../context';
 
-import { StyledListItem } from './styled';
+import { StyledDropdownItem } from './styled';
 
 export type Props = React.ComponentPropsWithoutRef<typeof ListItem> & {
   searchAs?: string | string[];
@@ -30,9 +30,9 @@ export const Component = ({ children, onClick, 'data-testid': testId, ...otherPr
   );
 
   return (
-    <StyledListItem {...otherProps} onClick={click} data-testid={buildTestId(testId)}>
+    <StyledDropdownItem {...otherProps} onClick={click} data-testid={buildTestId(testId)}>
       {children}
-    </StyledListItem>
+    </StyledDropdownItem>
   );
 };
 

--- a/src/components/Select/Option/styled.tsx
+++ b/src/components/Select/Option/styled.tsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import { em } from 'polished';
 
-import { ListItem } from '../../ListItem';
+import { Dropdown } from '../../Dropdown';
 
-export const StyledListItem = styled(ListItem)`
+export const StyledDropdownItem = styled(Dropdown.Item)`
   font-size: ${({ theme }) => em(theme.honeycomb.size.reduced)};
   padding: ${({ theme }) => em(theme.honeycomb.size.normal, theme.honeycomb.size.reduced)}
     ${({ theme }) => em(theme.honeycomb.size.small, theme.honeycomb.size.reduced)};
   height: auto;
+  border-bottom: 1px solid ${({ theme }) => theme.honeycomb.color.border};
 `;

--- a/src/components/Select/context.tsx
+++ b/src/components/Select/context.tsx
@@ -4,7 +4,7 @@ import { Variant } from './component';
 
 export const Context = React.createContext<{
   onClose?: () => void;
-  variant?: Variant;
+  variant: Variant;
   isShowing: boolean;
   testId?: string;
-}>({ isShowing: false });
+}>({ isShowing: false, variant: 'responsive' });

--- a/src/components/Select/variant/DropdownSelect/component.tsx
+++ b/src/components/Select/variant/DropdownSelect/component.tsx
@@ -1,34 +1,20 @@
 import React from 'react';
 
 import { useBuildTestId } from '../../../../modules/test-ids';
+import { Dropdown } from '../../../Dropdown';
 import { Select } from '../../../Select';
-import { Tooltip } from '../../../Tooltip';
 
 import { Styled } from './styled';
 
 export type Props = React.ComponentProps<typeof Select>;
 
-export const Component = ({
-  target,
-  variant,
-  onClose,
-  'data-testid': testId,
-  ...otherProps
-}: Props) => {
+export const Component = ({ children, target, 'data-testid': testId }: Props) => {
   const { buildTestId } = useBuildTestId({ id: testId });
 
   return (
-    <Tooltip
-      interactive={true}
-      arrow={false}
-      content={<Styled>{otherProps.children}</Styled>}
-      visible={otherProps.open}
-      onClickOutside={onClose}
-      data-testid={buildTestId()}
-      bare
-    >
-      {target}
-    </Tooltip>
+    <Dropdown bare target={target} data-testid={buildTestId()}>
+      <Styled>{children}</Styled>
+    </Dropdown>
   );
 };
 

--- a/src/cypress/Modal.stories.tsx
+++ b/src/cypress/Modal.stories.tsx
@@ -4,8 +4,9 @@ import { em } from 'polished';
 
 import { Button } from '../components/Button';
 import { Dropdown } from '../components/Dropdown';
-import { Code } from '../components/internal/Docs';
 import { Modal } from '../components/Modal';
+import { Select } from '../components/Select';
+import { Space } from '../components/Space';
 import { Text } from '../components/Text';
 import { Sections } from '../modules/sections';
 
@@ -24,6 +25,7 @@ const Guide = styled(Text)`
 export const Default = () => {
   const [show, setShow] = useState(false);
   const [showInner, setShowInner] = useState(false);
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
 
   return (
     <>
@@ -36,32 +38,34 @@ export const Default = () => {
           <Button variant="primary" onClick={() => setShowInner(true)} data-testid="open-btn-inner">
             Show inner modal
           </Button>
-          <Modal
-            open={showInner}
-            onClose={() => setShowInner(false)}
-            closeOnBackgroundClick={false}
-            data-testid="modal-inner"
-          >
+          <Modal open={showInner} onClose={() => setShowInner(false)} data-testid="modal-inner">
             <Modal.Header title="Inner Modal" />
             <Modal.Content>
               <Guide size="reduced">
-                If you put an element like <Code>Dropdown</Code> inside a modal, make sure
-                <Code>closeOnBackgroundClick=&#123;false&#125;</Code> (default).
-              </Guide>
-              <Guide size="reduced">
-                Otherwise the modal will be closed when clicking outside of the dropdown.
+                This is to test that closing a dropdown by background click does not close the
+                modal.
               </Guide>
               <Dropdown
                 target={<Dropdown.DefaultTarget>Dropdown</Dropdown.DefaultTarget>}
                 appendTo={appendTo}
                 data-testid="dropdown"
               >
-                {new Array(5).fill(null).map((_, index) => (
-                  <Dropdown.Item key={index} data-testid={`${index}`}>
-                    Option {index + 1}
-                  </Dropdown.Item>
-                ))}
+                <Dropdown.Item data-testid="option">Option</Dropdown.Item>
               </Dropdown>
+              <Space size="normal" />
+              <Select
+                open={isSelectOpen}
+                onClose={() => setIsSelectOpen(false)}
+                variant="dropdown"
+                target={
+                  <Select.DefaultTarget onClick={() => setIsSelectOpen((value) => !value)}>
+                    Select
+                  </Select.DefaultTarget>
+                }
+                data-testid="select"
+              >
+                <Select.Option data-testid="option">Option</Select.Option>
+              </Select>
             </Modal.Content>
           </Modal>
         </Modal.Content>


### PR DESCRIPTION
Resolves [#1328](https://github.com/binance-chain/ui-project-management/issues/1328).

- Fix `<Dropdown />` close on background click event propagating.
- Refactor `<Select />` to internally use `<Dropdown />` as it has the same issue.
- Default `closeOnBackgroundClick` in `<Modal />` to `true.`
- Add test.