### PR TITLE
feat: add classname for modal property

### DIFF
--- a/src/components/Select/component.tsx
+++ b/src/components/Select/component.tsx
@@ -41,6 +41,7 @@ export type Props = Pick<React.HTMLProps<HTMLElement>, 'children'> &
     target: React.ReactNode;
     open?: boolean;
     onClose?: () => void;
+    className?: string;
   };
 
 export const Component = ({


### PR DESCRIPTION
<img width="1365" alt="Screen Shot 2021-12-29 at 17 57 44" src="https://user-images.githubusercontent.com/30541586/147650431-7688dfe6-8fc5-4e3c-98db-3f4e8e09099a.png">

When we use select modal on the swap page, after chosing the option, the select modal will actually be closed after some seconds, which casing a performance issue when testing. Not quite sure why there are two timeouts here, I added the classname to solve the issue for now. @essj 
